### PR TITLE
MGT: Lower CMake minimum version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 
 # -------------------------------------------------- #
 # LIB HELPER                                         #


### PR DESCRIPTION
Ubuntu on WSL only has 3.16 so we need this to compile on Windows machines. Also there are no breaking changes from our point of view.