### PR TITLE
Attempted to reduce redundancy in exception throwing in math/kalman_m…

### DIFF
--- a/src/utils/math/kalman_multivariate.cpp
+++ b/src/utils/math/kalman_multivariate.cpp
@@ -132,7 +132,7 @@ MatrixXf &KalmanMultivariate::getStateCovariance()
  * @param expected The actual matrix dimensions we were expecting.    
  */
 
-void throwMatrixDimensionException(int expected) {
+void throwMatrixDimensionException(const int expected) {
     throw std::invalid_argument("Wrong matrix dimensions: expected row/column number is : " + expected); 
 }
 
@@ -140,7 +140,7 @@ void throwMatrixDimensionException(int expected) {
  * @brief Helper function for throwing exceptions in case of incorrect matrix dimensions - no parameters version. 
  */
 
-void throwMatrixDimensionException(int expected) {
+void throwMatrixDimensionException() {
     throw std::invalid_argument("Wrong dimension of the Matrices");
 }
 


### PR DESCRIPTION
…ultivariate.cpp

## Description
Create helper functions for throwing exceptions regarding incorrect matrix dimensions to reduce redundancy in code.

## Changes
- Create two helper functions to replace throwing "invalid_argument" exceptions relating to incorrect dimensions
