### PR TITLE
Mtc fake_controller.[ch]pp cleanup

### DIFF
--- a/src/propulsion/fake_controller.cpp
+++ b/src/propulsion/fake_controller.cpp
@@ -3,12 +3,12 @@
 namespace hyped {
 namespace motor_control {
 
-FakeController::FakeController(utils::Logger &log, const uint8_t id, const bool isFaulty)
+FakeController::FakeController(utils::Logger &log, const uint8_t id, const bool is_faulty)
     : log_(log),
       data_(data::Data::getInstance()),
       motor_data_(data_.getMotorData()),
       id_(id),
-      isFaulty_(isFaulty),
+      is_faulty_(is_faulty),
       critical_failure_(false),
       actual_velocity_(0),
       start_time_(0),
@@ -28,7 +28,7 @@ void FakeController::configure()
 
 void FakeController::startTimer()
 {
-  start_time_    = utils::Timer::getTimeMicros();  // time in microseconds
+  start_time_    = utils::Timer::getTimeMicros();
   timer_started_ = true;
   fail_time_
     = std::rand() % 20000000 + 1000000;  // failure occurs between seconds 1 and 21 of the run
@@ -77,7 +77,7 @@ void FakeController::quickStop()
 
 void FakeController::healthCheck()
 {
-  if (!isFaulty_) { return; }
+  if (!is_faulty_) { return; }
   const data::State state = data_.getStateMachineData().current_state;
   if (state != data::State::kAccelerating && state != data::State::kCruising
       && state != data::State::kNominalBraking) {

--- a/src/propulsion/fake_controller.hpp
+++ b/src/propulsion/fake_controller.hpp
@@ -15,7 +15,7 @@ class FakeController : public ControllerInterface {
   /**
    * @brief  Construct a new Fake Controller object
    */
-  FakeController(utils::Logger &log, const uint8_t id, const bool isFaulty);
+  FakeController(utils::Logger &log, const uint8_t id, const bool is_faulty);
   /**
    * @brief  Registers controller to recieve and transmit CAN messages.
    *         note: empty implementation.
@@ -104,7 +104,7 @@ class FakeController : public ControllerInterface {
   ControllerState state_;
   utils::Timer timer_;
   uint8_t id_;
-  bool isFaulty_;
+  bool is_faulty_;
   bool critical_failure_;
   int32_t actual_velocity_;
   uint64_t start_time_;


### PR DESCRIPTION
## Description
Cleans fake_controller.[ch]pp and aligns with style guide

## Changes
- Removed `using`
- Removed unneccessary `namespace utils`