### PR TITLE
NAV: IMU Data Logger Cleanup

### DIFF
--- a/src/navigation/imu_data_logger.cpp
+++ b/src/navigation/imu_data_logger.cpp
@@ -18,7 +18,7 @@ void ImuDataLogger::setup(const int imu_id, const int run_id)
   snprintf(buff, sizeof(buff), "test_data/run%d/imu%d/data.csv", run_id, imu_id);
   file_path_ = buff;
   outfile_->open(file_path_);
-  *outfile_ << "arx,ary,arz,acx,acy,acz,t\n";
+  *outfile_ << "arx,ary,arz,acx,acy,acz,t" << std::endl;
 }
 
 void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
@@ -27,31 +27,43 @@ void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
   snprintf(buff, sizeof(buff), "test_data/run%d/imu%d/data.csv", run_id, imu_id);
   file_path_ = buff;
   outfile_->open(file_path_);
-  *outfile_ << "arx,ary,arz,acx,acy,acz,afx,afy,afz,t\n";
+  *outfile_ << "arx,ary,arz,acx,acy,acz,afx,afy,afz,t" << std::endl;
 }
 
 void ImuDataLogger::dataToFileSimulation(data::NavigationVector &acceleration, uint32_t timestamp)
 {
-  *outfile_ << acceleration[0] << "," << acceleration[1] << "," << acceleration[2] << ","
-            << timestamp << "\n";
+  *outfile_ << acceleration[0] << ",";
+  *outfile_ << acceleration[1] << ",";
+  *outfile_ << acceleration[2] << ",";
+  *outfile_ << timestamp << std::endl;
 }
 
 void ImuDataLogger::dataToFile(data::NavigationVector &raw_acceleration,
                                data::NavigationVector &calibrated_acceleration, uint32_t timestamp)
 {
-  *outfile_ << raw_acceleration[0] << "," << raw_acceleration[1] << "," << raw_acceleration[2]
-            << "," << calibrated_acceleration[0] << "," << calibrated_acceleration[1] << ","
-            << calibrated_acceleration[2] << "," << timestamp << "\n";
+  *outfile_ << raw_acceleration[0] << ",";
+  *outfile_ << raw_acceleration[1] << ",";
+  *outfile_ << raw_acceleration[2] << ",";
+  *outfile_ << calibrated_acceleration[0] << ",";
+  *outfile_ << calibrated_acceleration[1] << ",";
+  *outfile_ << calibrated_acceleration[2] << ",";
+  *outfile_ << timestamp << std::endl;
 }
 
 void ImuDataLogger::dataToFileKalman(data::NavigationVector &raw_acceleration,
                                      data::NavigationVector &calibrated_acceleration,
                                      data::NavigationVector &x, uint32_t timestamp)
 {
-  *outfile_ << raw_acceleration[0] << "," << raw_acceleration[1] << "," << raw_acceleration[2]
-            << "," << calibrated_acceleration[0] << "," << calibrated_acceleration[1] << ","
-            << calibrated_acceleration[2] << "," << x[0] << "," << x[1] << "," << x[2] << ","
-            << timestamp << "\n";
+  *outfile_ << raw_acceleration[0] << ",";
+  *outfile_ << raw_acceleration[1] << ",";
+  *outfile_ << raw_acceleration[2] << ",";
+  *outfile_ << calibrated_acceleration[0] << ",";
+  *outfile_ << calibrated_acceleration[1] << ",";
+  *outfile_ << calibrated_acceleration[2] << ",";
+  *outfile_ << x[0] << ",";
+  *outfile_ << x[1] << ",";
+  *outfile_ << x[2] << ",";
+  *outfile_ << timestamp << std::endl;
 }
 
 }  // namespace navigation

--- a/src/navigation/imu_data_logger.cpp
+++ b/src/navigation/imu_data_logger.cpp
@@ -14,18 +14,18 @@ ImuDataLogger::~ImuDataLogger()
 
 void ImuDataLogger::setup(const int imu_id, const int run_id)
 {
-  char buff[100];
-  snprintf(buff, sizeof(buff), "test_data/run%d/imu%d/data.csv", run_id, imu_id);
-  file_path_ = buff;
+  std::ostringstream stream;
+  stream << "test_data/run" << run_id << "/imu" << imu_id << "/data.csv";
+  file_path_ = stream.str();
   outfile_->open(file_path_);
   *outfile_ << "arx,ary,arz,acx,acy,acz,t" << std::endl;
 }
 
 void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
 {
-  char buff[100];
-  snprintf(buff, sizeof(buff), "test_data/run%d/imu%d/data.csv", run_id, imu_id);
-  file_path_ = buff;
+  std::ostringstream stream;
+  stream << "test_data/run" << run_id << "/imu" << imu_id << "/data.csv";
+  file_path_ = stream.str();
   outfile_->open(file_path_);
   *outfile_ << "arx,ary,arz,acx,acy,acz,afx,afy,afz,t" << std::endl;
 }

--- a/src/navigation/imu_data_logger.cpp
+++ b/src/navigation/imu_data_logger.cpp
@@ -6,13 +6,13 @@
 namespace hyped {
 namespace navigation {
 
-ImuDataLogger::ImuDataLogger() : file_path_(), outfile_(new std::ofstream())
+ImuDataLogger::ImuDataLogger() : file_path_()
 {
 }
 
 ImuDataLogger::~ImuDataLogger()
 {
-  outfile_->close();
+  outfile_.close();
 }
 
 void ImuDataLogger::setup(const int imu_id, const int run_id)
@@ -20,8 +20,8 @@ void ImuDataLogger::setup(const int imu_id, const int run_id)
   std::ostringstream stream;
   stream << "test_data/run" << run_id << "/imu" << imu_id << "/data.csv";
   file_path_ = stream.str();
-  outfile_->open(file_path_);
-  *outfile_ << "arx,ary,arz,acx,acy,acz,t" << std::endl;
+  outfile_.open(file_path_);
+  outfile_ << "arx,ary,arz,acx,acy,acz,t" << std::endl;
 }
 
 void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
@@ -29,17 +29,17 @@ void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
   std::ostringstream stream;
   stream << "test_data/run" << run_id << "/imu" << imu_id << "/data.csv";
   file_path_ = stream.str();
-  outfile_->open(file_path_);
-  *outfile_ << "arx,ary,arz,acx,acy,acz,afx,afy,afz,t" << std::endl;
+  outfile_.open(file_path_);
+  outfile_ << "arx,ary,arz,acx,acy,acz,afx,afy,afz,t" << std::endl;
 }
 
 void ImuDataLogger::dataToFileSimulation(const data::NavigationVector &acceleration,
                                          const uint32_t timestamp)
 {
   for (std::size_t i = 0; i < 3; i++) {
-    *outfile_ << acceleration[i] << ",";
+    outfile_ << acceleration[i] << ",";
   }
-  *outfile_ << timestamp << std::endl;
+  outfile_ << timestamp << std::endl;
 }
 
 void ImuDataLogger::dataToFile(const data::NavigationVector &raw_acceleration,
@@ -47,12 +47,12 @@ void ImuDataLogger::dataToFile(const data::NavigationVector &raw_acceleration,
                                const uint32_t timestamp)
 {
   for (std::size_t i = 0; i < 3; i++) {
-    *outfile_ << raw_acceleration[i] << ",";
+    outfile_ << raw_acceleration[i] << ",";
   }
   for (std::size_t i = 0; i < 3; i++) {
-    *outfile_ << calibrated_acceleration[i] << ",";
+    outfile_ << calibrated_acceleration[i] << ",";
   }
-  *outfile_ << timestamp << std::endl;
+  outfile_ << timestamp << std::endl;
 }
 
 void ImuDataLogger::dataToFileKalman(const data::NavigationVector &raw_acceleration,
@@ -60,15 +60,15 @@ void ImuDataLogger::dataToFileKalman(const data::NavigationVector &raw_accelerat
                                      const data::NavigationVector &x, const uint32_t timestamp)
 {
   for (std::size_t i = 0; i < 3; i++) {
-    *outfile_ << raw_acceleration[i] << ",";
+    outfile_ << raw_acceleration[i] << ",";
   }
   for (std::size_t i = 0; i < 3; i++) {
-    *outfile_ << calibrated_acceleration[i] << ",";
+    outfile_ << calibrated_acceleration[i] << ",";
   }
   for (std::size_t i = 0; i < 3; i++) {
-    *outfile_ << x[i] << ",";
+    outfile_ << x[i] << ",";
   }
-  *outfile_ << timestamp << std::endl;
+  outfile_ << timestamp << std::endl;
 }
 
 }  // namespace navigation

--- a/src/navigation/imu_data_logger.cpp
+++ b/src/navigation/imu_data_logger.cpp
@@ -1,5 +1,8 @@
 #include "imu_data_logger.hpp"
 
+#include <fstream>
+#include <sstream>
+
 namespace hyped {
 namespace navigation {
 

--- a/src/navigation/imu_data_logger.cpp
+++ b/src/navigation/imu_data_logger.cpp
@@ -36,9 +36,9 @@ void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
 void ImuDataLogger::dataToFileSimulation(const data::NavigationVector &acceleration,
                                          const uint32_t timestamp)
 {
-  *outfile_ << acceleration[0] << ",";
-  *outfile_ << acceleration[1] << ",";
-  *outfile_ << acceleration[2] << ",";
+  for (std::size_t i = 0; i < 3; i++) {
+    *outfile_ << acceleration[i] << ",";
+  }
   *outfile_ << timestamp << std::endl;
 }
 
@@ -46,12 +46,12 @@ void ImuDataLogger::dataToFile(const data::NavigationVector &raw_acceleration,
                                const data::NavigationVector &calibrated_acceleration,
                                const uint32_t timestamp)
 {
-  *outfile_ << raw_acceleration[0] << ",";
-  *outfile_ << raw_acceleration[1] << ",";
-  *outfile_ << raw_acceleration[2] << ",";
-  *outfile_ << calibrated_acceleration[0] << ",";
-  *outfile_ << calibrated_acceleration[1] << ",";
-  *outfile_ << calibrated_acceleration[2] << ",";
+  for (std::size_t i = 0; i < 3; i++) {
+    *outfile_ << raw_acceleration[i] << ",";
+  }
+  for (std::size_t i = 0; i < 3; i++) {
+    *outfile_ << calibrated_acceleration[i] << ",";
+  }
   *outfile_ << timestamp << std::endl;
 }
 
@@ -59,15 +59,15 @@ void ImuDataLogger::dataToFileKalman(const data::NavigationVector &raw_accelerat
                                      const data::NavigationVector &calibrated_acceleration,
                                      const data::NavigationVector &x, const uint32_t timestamp)
 {
-  *outfile_ << raw_acceleration[0] << ",";
-  *outfile_ << raw_acceleration[1] << ",";
-  *outfile_ << raw_acceleration[2] << ",";
-  *outfile_ << calibrated_acceleration[0] << ",";
-  *outfile_ << calibrated_acceleration[1] << ",";
-  *outfile_ << calibrated_acceleration[2] << ",";
-  *outfile_ << x[0] << ",";
-  *outfile_ << x[1] << ",";
-  *outfile_ << x[2] << ",";
+  for (std::size_t i = 0; i < 3; i++) {
+    *outfile_ << raw_acceleration[i] << ",";
+  }
+  for (std::size_t i = 0; i < 3; i++) {
+    *outfile_ << calibrated_acceleration[i] << ",";
+  }
+  for (std::size_t i = 0; i < 3; i++) {
+    *outfile_ << x[i] << ",";
+  }
   *outfile_ << timestamp << std::endl;
 }
 

--- a/src/navigation/imu_data_logger.cpp
+++ b/src/navigation/imu_data_logger.cpp
@@ -12,7 +12,7 @@ ImuDataLogger::~ImuDataLogger()
   outfile_->close();
 }
 
-void ImuDataLogger::setup(int imu_id, int run_id)
+void ImuDataLogger::setup(const int imu_id, const int run_id)
 {
   char buff[100];
   snprintf(buff, sizeof(buff), "test_data/run%d/imu%d/data.csv", run_id, imu_id);
@@ -21,7 +21,7 @@ void ImuDataLogger::setup(int imu_id, int run_id)
   *outfile_ << "arx,ary,arz,acx,acy,acz,t\n";
 }
 
-void ImuDataLogger::setupKalman(int imu_id, int run_id)
+void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
 {
   char buff[100];
   snprintf(buff, sizeof(buff), "test_data/run%d/imu%d/data.csv", run_id, imu_id);
@@ -30,23 +30,28 @@ void ImuDataLogger::setupKalman(int imu_id, int run_id)
   *outfile_ << "arx,ary,arz,acx,acy,acz,afx,afy,afz,t\n";
 }
 
-void ImuDataLogger::dataToFileSimulation(NavigationVector &acc, uint32_t timestamp)
+void ImuDataLogger::dataToFileSimulation(data::NavigationVector &acceleration, uint32_t timestamp)
 {
-  *outfile_ << acc[0] << "," << acc[1] << "," << acc[2] << "," << timestamp << "\n";
+  *outfile_ << acceleration[0] << "," << acceleration[1] << "," << acceleration[2] << ","
+            << timestamp << "\n";
 }
 
-void ImuDataLogger::dataToFile(NavigationVector &accR, NavigationVector &accC, uint32_t timestamp)
+void ImuDataLogger::dataToFile(data::NavigationVector &raw_acceleration,
+                               data::NavigationVector &calibrated_acceleration, uint32_t timestamp)
 {
-  *outfile_ << accR[0] << "," << accR[1] << "," << accR[2] << "," << accC[0] << "," << accC[1]
-            << "," << accC[2] << "," << timestamp << "\n";
+  *outfile_ << raw_acceleration[0] << "," << raw_acceleration[1] << "," << raw_acceleration[2]
+            << "," << calibrated_acceleration[0] << "," << calibrated_acceleration[1] << ","
+            << calibrated_acceleration[2] << "," << timestamp << "\n";
 }
 
-void ImuDataLogger::dataToFileKalman(NavigationVector &accR, NavigationVector &accC,
-                                     NavigationVector &x, uint32_t timestamp)
+void ImuDataLogger::dataToFileKalman(data::NavigationVector &raw_acceleration,
+                                     data::NavigationVector &calibrated_acceleration,
+                                     data::NavigationVector &x, uint32_t timestamp)
 {
-  *outfile_ << accR[0] << "," << accR[1] << "," << accR[2] << "," << accC[0] << "," << accC[1]
-            << "," << accC[2] << "," << x[0] << "," << x[1] << "," << x[2] << "," << timestamp
-            << "\n";
+  *outfile_ << raw_acceleration[0] << "," << raw_acceleration[1] << "," << raw_acceleration[2]
+            << "," << calibrated_acceleration[0] << "," << calibrated_acceleration[1] << ","
+            << calibrated_acceleration[2] << "," << x[0] << "," << x[1] << "," << x[2] << ","
+            << timestamp << "\n";
 }
 
 }  // namespace navigation

--- a/src/navigation/imu_data_logger.cpp
+++ b/src/navigation/imu_data_logger.cpp
@@ -30,7 +30,8 @@ void ImuDataLogger::setupKalman(const int imu_id, const int run_id)
   *outfile_ << "arx,ary,arz,acx,acy,acz,afx,afy,afz,t" << std::endl;
 }
 
-void ImuDataLogger::dataToFileSimulation(data::NavigationVector &acceleration, uint32_t timestamp)
+void ImuDataLogger::dataToFileSimulation(const data::NavigationVector &acceleration,
+                                         const uint32_t timestamp)
 {
   *outfile_ << acceleration[0] << ",";
   *outfile_ << acceleration[1] << ",";
@@ -38,8 +39,9 @@ void ImuDataLogger::dataToFileSimulation(data::NavigationVector &acceleration, u
   *outfile_ << timestamp << std::endl;
 }
 
-void ImuDataLogger::dataToFile(data::NavigationVector &raw_acceleration,
-                               data::NavigationVector &calibrated_acceleration, uint32_t timestamp)
+void ImuDataLogger::dataToFile(const data::NavigationVector &raw_acceleration,
+                               const data::NavigationVector &calibrated_acceleration,
+                               const uint32_t timestamp)
 {
   *outfile_ << raw_acceleration[0] << ",";
   *outfile_ << raw_acceleration[1] << ",";
@@ -50,9 +52,9 @@ void ImuDataLogger::dataToFile(data::NavigationVector &raw_acceleration,
   *outfile_ << timestamp << std::endl;
 }
 
-void ImuDataLogger::dataToFileKalman(data::NavigationVector &raw_acceleration,
-                                     data::NavigationVector &calibrated_acceleration,
-                                     data::NavigationVector &x, uint32_t timestamp)
+void ImuDataLogger::dataToFileKalman(const data::NavigationVector &raw_acceleration,
+                                     const data::NavigationVector &calibrated_acceleration,
+                                     const data::NavigationVector &x, const uint32_t timestamp)
 {
   *outfile_ << raw_acceleration[0] << ",";
   *outfile_ << raw_acceleration[1] << ",";

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -11,9 +11,6 @@
 #include <data/data_point.hpp>
 
 namespace hyped {
-using data::DataPoint;
-using data::nav_t;
-using data::NavigationVector;
 
 namespace navigation {
 
@@ -23,9 +20,11 @@ class ImuDataLogger {
   ~ImuDataLogger();
   void setup(int imu_id, int run_id);
   void setupKalman(int imu_id, int run_id);
-  void dataToFileSimulation(NavigationVector &acc, uint32_t timestamp);
-  void dataToFile(NavigationVector &accRaw, NavigationVector &accCor, uint32_t timestamp);
-  void dataToFileKalman(NavigationVector &accRaw, NavigationVector &accCor, NavigationVector &x,
+  void dataToFileSimulation(data::NavigationVector &acceleration, uint32_t timestamp);
+  void dataToFile(data::NavigationVector &raw_acceleration,
+                  data::NavigationVector &calibrated_acceleration, uint32_t timestamp);
+  void dataToFileKalman(data::NavigationVector &raw_acceleration,
+                        data::NavigationVector &calibrated_acceleration, data::NavigationVector &x,
                         uint32_t timestamp);
 
  private:

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <fstream>
+#include <sstream>
 #include <string>
 
 #include <data/data.hpp>

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -21,12 +21,12 @@ class ImuDataLogger {
   ~ImuDataLogger();
   void setup(int imu_id, int run_id);
   void setupKalman(int imu_id, int run_id);
-  void dataToFileSimulation(data::NavigationVector &acceleration, uint32_t timestamp);
-  void dataToFile(data::NavigationVector &raw_acceleration,
-                  data::NavigationVector &calibrated_acceleration, uint32_t timestamp);
-  void dataToFileKalman(data::NavigationVector &raw_acceleration,
-                        data::NavigationVector &calibrated_acceleration, data::NavigationVector &x,
-                        uint32_t timestamp);
+  void dataToFileSimulation(const data::NavigationVector &acceleration, const uint32_t timestamp);
+  void dataToFile(const data::NavigationVector &raw_acceleration,
+                  const data::NavigationVector &calibrated_acceleration, const uint32_t timestamp);
+  void dataToFileKalman(const data::NavigationVector &raw_acceleration,
+                        const data::NavigationVector &calibrated_acceleration,
+                        const data::NavigationVector &x, const uint32_t timestamp);
 
  private:
   std::string file_path_;

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -15,6 +15,10 @@ namespace navigation {
 
 class ImuDataLogger {
  public:
+  /**
+   * @brief Construct a new Imu Data Logger object
+   * 
+   */
   ImuDataLogger();
   ~ImuDataLogger();
 

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <fstream>
 #include <string>
 
 #include <data/data.hpp>
@@ -17,7 +18,7 @@ class ImuDataLogger {
  public:
   /**
    * @brief Construct a new Imu Data Logger object
-   * 
+   *
    */
   ImuDataLogger();
   ~ImuDataLogger();
@@ -72,7 +73,7 @@ class ImuDataLogger {
 
  private:
   std::string file_path_;
-  std::ofstream *outfile_;
+  std::ofstream outfile_;
 };
 }  // namespace navigation
 }  // namespace hyped

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -4,8 +4,6 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <fstream>
-#include <sstream>
 #include <string>
 
 #include <data/data.hpp>
@@ -19,11 +17,52 @@ class ImuDataLogger {
  public:
   ImuDataLogger();
   ~ImuDataLogger();
+
+  /**
+   * @brief setup outfile
+   *
+   * @param imu_id ID for IMU
+   * @param run_id ID for run
+   */
   void setup(int imu_id, int run_id);
+
+  /**
+   * @brief setup outfile for Kalman
+   *
+   * @param imu_id ID for IMU
+   * @param run_id ID for run
+   */
   void setupKalman(int imu_id, int run_id);
+
+  /**
+   * @brief write simulation acceleration to the outfile
+   *
+   * @param acceleration a vector of type nav_t (float) holding acceleration
+   * @param timestamp time that data was received
+   */
   void dataToFileSimulation(const data::NavigationVector &acceleration, const uint32_t timestamp);
+
+  /**
+   * @brief write raw and calibrated accelerations to outfile
+   *
+   * @param raw_acceleration a vector of type nav_t (float) holding the raw acceleration
+   * @param calibrated_acceleration a vector of type nav_t (float) holding the acceleration after
+   * filtering
+   * @param timestamp time that data was received
+   */
   void dataToFile(const data::NavigationVector &raw_acceleration,
                   const data::NavigationVector &calibrated_acceleration, const uint32_t timestamp);
+
+  /**
+   * @brief write raw, calibrated and x accelerations to outfile
+   *
+   * @param raw_acceleration a vector of type nav_t (float) holding the raw acceleration
+   * @param calibrated_acceleration a vector of type nav_t (float) holding the acceleration after
+   * filtering
+   * @param x // (TODO - rename x, we are currently unsure what exactly it is and what it is used
+   * for)
+   * @param timestamp time that data was received
+   */
   void dataToFileKalman(const data::NavigationVector &raw_acceleration,
                         const data::NavigationVector &calibrated_acceleration,
                         const data::NavigationVector &x, const uint32_t timestamp);

--- a/src/navigation/imu_data_logger.hpp
+++ b/src/navigation/imu_data_logger.hpp
@@ -59,8 +59,7 @@ class ImuDataLogger {
    * @param raw_acceleration a vector of type nav_t (float) holding the raw acceleration
    * @param calibrated_acceleration a vector of type nav_t (float) holding the acceleration after
    * filtering
-   * @param x // (TODO - rename x, we are currently unsure what exactly it is and what it is used
-   * for)
+   * @param x //TODO:(rename x, we are currently unsure what exactly it is and what it is used for)
    * @param timestamp time that data was received
    */
   void dataToFileKalman(const data::NavigationVector &raw_acceleration,

--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -32,7 +32,7 @@ void MainLog::calibrateGravity()
   std::array<OnlineStatistics<NavigationVector>, data::Sensors::kNumImus> online_array;
   // Average each sensor over specified number of readings
   for (int i = 0; i < kNumCalibrationQueries; ++i) {
-    DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
+    data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     for (int j = 0; j < data::Sensors::kNumImus; ++j) {
       online_array[j].update(sensor_readings.value[j].acc);
     }
@@ -51,7 +51,7 @@ void MainLog::run()
   log_.INFO("NAV", "Logging starting");
 
   while (sys_.running_) {
-    DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
+    data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     for (int i = 0; i < data::Sensors::kNumImus; ++i) {
       // Apply calibrated correction
       NavigationVector acc     = sensor_readings.value[i].acc;

--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -17,7 +17,7 @@ MainLog::MainLog(uint8_t id, Logger &log)
   log_.INFO("NAV", "Logging initialising");
   calibrateGravity();
 
-  for (unsigned int i = 0; i < data::Sensors::kNumImus; i++) {
+  for (std::size_t i = 0; i < data::Sensors::kNumImus; i++) {
     imu_loggers_[i] = ImuDataLogger();
     imu_loggers_[i].setup(i, sys_.run_id);
   }
@@ -31,14 +31,14 @@ void MainLog::calibrateGravity()
   log_.INFO("NAV", "Calibrating gravity");
   std::array<OnlineStatistics<NavigationVector>, data::Sensors::kNumImus> online_array;
   // Average each sensor over specified number of readings
-  for (int i = 0; i < kNumCalibrationQueries; ++i) {
+  for (std::size_t i = 0; i < kNumCalibrationQueries; ++i) {
     data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
-    for (int j = 0; j < data::Sensors::kNumImus; ++j) {
+    for (std::size_t j = 0; j < data::Sensors::kNumImus; ++j) {
       online_array[j].update(sensor_readings.value[j].acc);
     }
     Thread::sleep(1);
   }
-  for (int j = 0; j < data::Sensors::kNumImus; ++j) {
+  for (std::size_t j = 0; j < data::Sensors::kNumImus; ++j) {
     gravity_calibration_[j] = online_array[j].getMean();
     log_.INFO("NAV",
               "Update: g=(%.5f, %.5f, %.5f)",  // NOLINT
@@ -52,7 +52,7 @@ void MainLog::run()
 
   while (sys_.running_) {
     data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
-    for (int i = 0; i < data::Sensors::kNumImus; ++i) {
+    for (std::size_t i = 0; i < data::Sensors::kNumImus; ++i) {
       // Apply calibrated correction
       NavigationVector acc     = sensor_readings.value[i].acc;
       NavigationVector acc_cor = acc - gravity_calibration_[i];

--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -18,7 +18,6 @@ MainLog::MainLog(uint8_t id, Logger &log)
   calibrateGravity();
 
   for (std::size_t i = 0; i < data::Sensors::kNumImus; i++) {
-    imu_loggers_[i] = ImuDataLogger();
     imu_loggers_[i].setup(i, sys_.run_id);
   }
   data::Navigation nav_data = data_.getNavigationData();


### PR DESCRIPTION
Cleans `imu_data_logger.cpp` and  `imu_data_logger.hpp`

## Changes
- Added `const`
- Removed `using`
- Fixed types
- Fixed variable names to adhere to Style Guide