### PR TITLE
changed char * to std::string and used .c_str() when calling

### DIFF
--- a/src/telemetry/client.cpp
+++ b/src/telemetry/client.cpp
@@ -38,7 +38,7 @@ bool Client::connect()
   hints.ai_socktype = SOCK_STREAM;
 
   // get possible addresses we can connect to
-  int error = getaddrinfo(kServerIP, kPort, &hints, &server_info);
+  int error = getaddrinfo(kServerIP.c_str(), kPort.c_str(), &hints, &server_info);
   if (error != 0) {
     log_.ERR("Telemetry", "%s", gai_strerror(error));
     throw std::runtime_error{"Failed getting possible addresses"};

--- a/src/telemetry/client.hpp
+++ b/src/telemetry/client.hpp
@@ -22,8 +22,8 @@ class Client {
 
   utils::Logger &log_;
   int sockfd_;
-  const char *kPort;
-  const char *kServerIP;
+  const std::string kPort;
+  const std::string kServerIP;
 };
 
 }  // namespace telemetry


### PR DESCRIPTION
## Description
Changes `char *` to `std::string` and calls `.c_str()` when passed to function expecting a `char *`