### PR TITLE
NAV: main_log.cpp/hpp Cleanup

### DIFF
--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -12,7 +12,7 @@ MainLog::MainLog(const uint8_t id, Logger &log)
     : Thread(id, log),
       log_(log),
       sys_(System::getSystem()),
-      data_(Data::getInstance())
+      data_(data::Data::getInstance())
 {
   log_.INFO("NAV", "Logging initialising");
   calibrateGravity();
@@ -54,11 +54,14 @@ void MainLog::run()
     DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     for (std::size_t i = 0; i < data::Sensors::kNumImus; ++i) {
       // Apply calibrated correction
-      NavigationVector acc     = sensor_readings.value[i].acc;
-      NavigationVector acc_cor = acc - gravity_calibration_[i];
-      log_.DBG("NAV", "%.3f %.3f %.3f / %.3f %.3f %.3f", acc[0], acc[1], acc[2], acc_cor[0],
-               acc_cor[1], acc_cor[2]);
-      imu_loggers_[i].dataToFile(acc_cor, acc, sensor_readings.timestamp);
+      NavigationVector acceleration
+        = sensor_readings.value[i].acc;  // TODO: .acc should be renamed to acceleration, but must
+                                         // be changed in data.hpp and other areas as
+      NavigationVector calibrated_acceleration = acceleration - gravity_calibration_[i];
+      log_.DBG("NAV", "%.3f %.3f %.3f / %.3f %.3f %.3f", acceleration[0], acceleration[1],
+               acceleration[2], calibrated_acceleration[0], calibrated_acceleration[1],
+               calibrated_acceleration[2]);
+      imu_loggers_[i].dataToFile(calibrated_acceleration, acceleration, sensor_readings.timestamp);
     }
   }
 }

--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -50,7 +50,6 @@ void MainLog::run()
   log_.INFO("NAV", "Logging starting");
 
   while (sys_.running_) {
-    DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     for (std::size_t i = 0; i < data::Sensors::kNumImus; ++i) {
       // Apply calibrated correction

--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -8,7 +8,7 @@ typedef std::array<ImuData, data::Sensors::kNumImus> ImuDataArray;
 
 namespace navigation {
 
-MainLog::MainLog(uint8_t id, Logger &log)
+MainLog::MainLog(const uint8_t id, Logger &log)
     : Thread(id, log),
       log_(log),
       sys_(System::getSystem()),
@@ -17,7 +17,7 @@ MainLog::MainLog(uint8_t id, Logger &log)
   log_.INFO("NAV", "Logging initialising");
   calibrateGravity();
 
-  for (unsigned int i = 0; i < data::Sensors::kNumImus; i++) {
+  for (std::size_t i = 0; i < data::Sensors::kNumImus; i++) {
     imu_loggers_[i] = ImuDataLogger();
     imu_loggers_[i].setup(i, sys_.run_id);
   }
@@ -31,14 +31,14 @@ void MainLog::calibrateGravity()
   log_.INFO("NAV", "Calibrating gravity");
   std::array<OnlineStatistics<NavigationVector>, data::Sensors::kNumImus> online_array;
   // Average each sensor over specified number of readings
-  for (int i = 0; i < kNumCalibrationQueries; ++i) {
+  for (std::size_t i = 0; i < kNumCalibrationQueries; ++i) {
     DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
-    for (int j = 0; j < data::Sensors::kNumImus; ++j) {
+    for (std::size_t j = 0; j < data::Sensors::kNumImus; ++j) {
       online_array[j].update(sensor_readings.value[j].acc);
     }
     Thread::sleep(1);
   }
-  for (int j = 0; j < data::Sensors::kNumImus; ++j) {
+  for (std::size_t j = 0; j < data::Sensors::kNumImus; ++j) {
     gravity_calibration_[j] = online_array[j].getMean();
     log_.INFO("NAV",
               "Update: g=(%.5f, %.5f, %.5f)",  // NOLINT
@@ -52,7 +52,7 @@ void MainLog::run()
 
   while (sys_.running_) {
     DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
-    for (int i = 0; i < data::Sensors::kNumImus; ++i) {
+    for (std::size_t i = 0; i < data::Sensors::kNumImus; ++i) {
       // Apply calibrated correction
       NavigationVector acc     = sensor_readings.value[i].acc;
       NavigationVector acc_cor = acc - gravity_calibration_[i];

--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -4,7 +4,7 @@
 
 namespace hyped {
 
-typedef std::array<data::ImuData, data::Sensors::kNumImus> ImuDataArray;
+using ImuDataArray = std::array<data::ImuData, data::Sensors::kNumImus>;
 
 namespace navigation {
 
@@ -53,9 +53,8 @@ void MainLog::run()
     data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     for (std::size_t i = 0; i < data::Sensors::kNumImus; ++i) {
       // Apply calibrated correction
-      data::NavigationVector acceleration
-        = sensor_readings.value.at(i).acc;  // TODO: .acc should be renamed to acceleration, but
-                                            // must be changed in data.hpp and other areas as
+      data::NavigationVector acceleration 
+        = sensor_readings.value.at(i).acc; // TODO: .acc should be renamed to acceleration, but must be changed in data.hpp and other areas
       data::NavigationVector calibrated_acceleration = acceleration - gravity_calibration_.at(i);
       log_.DBG("NAV", "%.3f %.3f %.3f / %.3f %.3f %.3f", acceleration[0], acceleration[1],
                acceleration[2], calibrated_acceleration[0], calibrated_acceleration[1],

--- a/src/navigation/main_log.cpp
+++ b/src/navigation/main_log.cpp
@@ -4,21 +4,21 @@
 
 namespace hyped {
 
-typedef std::array<ImuData, data::Sensors::kNumImus> ImuDataArray;
+typedef std::array<data::ImuData, data::Sensors::kNumImus> ImuDataArray;
 
 namespace navigation {
 
-MainLog::MainLog(const uint8_t id, Logger &log)
-    : Thread(id, log),
+MainLog::MainLog(const uint8_t id, utils::Logger &log)
+    : utils::concurrent::Thread(id, log),
       log_(log),
-      sys_(System::getSystem()),
+      sys_(utils::System::getSystem()),
       data_(data::Data::getInstance())
 {
   log_.INFO("NAV", "Logging initialising");
   calibrateGravity();
 
   for (std::size_t i = 0; i < data::Sensors::kNumImus; i++) {
-    imu_loggers_[i].setup(i, sys_.run_id);
+    imu_loggers_.at(i).setup(i, sys_.run_id);
   }
   data::Navigation nav_data = data_.getNavigationData();
   nav_data.module_status    = data::ModuleStatus::kReady;
@@ -28,20 +28,20 @@ MainLog::MainLog(const uint8_t id, Logger &log)
 void MainLog::calibrateGravity()
 {
   log_.INFO("NAV", "Calibrating gravity");
-  std::array<OnlineStatistics<NavigationVector>, data::Sensors::kNumImus> online_array;
+  std::array<utils::math::OnlineStatistics<data::NavigationVector>, data::Sensors::kNumImus>
+    online_array;
   // Average each sensor over specified number of readings
   for (std::size_t i = 0; i < kNumCalibrationQueries; ++i) {
     data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     for (std::size_t j = 0; j < data::Sensors::kNumImus; ++j) {
-      online_array[j].update(sensor_readings.value[j].acc);
+      online_array.at(i).update(sensor_readings.value.at(j).acc);
     }
-    Thread::sleep(1);
+    utils::concurrent::Thread::sleep(1);
   }
   for (std::size_t j = 0; j < data::Sensors::kNumImus; ++j) {
-    gravity_calibration_[j] = online_array[j].getMean();
-    log_.INFO("NAV",
-              "Update: g=(%.5f, %.5f, %.5f)",  // NOLINT
-              gravity_calibration_[j][0], gravity_calibration_[j][1], gravity_calibration_[j][2]);
+    gravity_calibration_.at(j) = online_array.at(j).getMean();
+    log_.INFO("NAV", "Update: g=(%.5f, %.5f, %.5f)", gravity_calibration_.at(j)[0],
+              gravity_calibration_.at(j)[1], gravity_calibration_.at(j)[2]);
   }
 }
 
@@ -53,14 +53,15 @@ void MainLog::run()
     data::DataPoint<ImuDataArray> sensor_readings = data_.getSensorsImuData();
     for (std::size_t i = 0; i < data::Sensors::kNumImus; ++i) {
       // Apply calibrated correction
-      NavigationVector acceleration
-        = sensor_readings.value[i].acc;  // TODO: .acc should be renamed to acceleration, but must
-                                         // be changed in data.hpp and other areas as
-      NavigationVector calibrated_acceleration = acceleration - gravity_calibration_[i];
+      data::NavigationVector acceleration
+        = sensor_readings.value.at(i).acc;  // TODO: .acc should be renamed to acceleration, but
+                                            // must be changed in data.hpp and other areas as
+      data::NavigationVector calibrated_acceleration = acceleration - gravity_calibration_.at(i);
       log_.DBG("NAV", "%.3f %.3f %.3f / %.3f %.3f %.3f", acceleration[0], acceleration[1],
                acceleration[2], calibrated_acceleration[0], calibrated_acceleration[1],
                calibrated_acceleration[2]);
-      imu_loggers_[i].dataToFile(calibrated_acceleration, acceleration, sensor_readings.timestamp);
+      imu_loggers_.at(i).dataToFile(calibrated_acceleration, acceleration,
+                                    sensor_readings.timestamp);
     }
   }
 }

--- a/src/navigation/main_log.hpp
+++ b/src/navigation/main_log.hpp
@@ -18,7 +18,6 @@
 
 namespace hyped {
 
-using data::Data;
 using data::ImuData;
 using data::NavigationVector;
 using navigation::ImuDataLogger;
@@ -29,8 +28,14 @@ using utils::math::OnlineStatistics;
 
 namespace navigation {
 
-class MainLog : public Thread {
+class MainLog : public utils::concurrent::Thread {
  public:
+  /**
+   * @brief Construct a new Main Log object
+   *
+   * @param id log ID
+   * @param log Logger object
+   */
   explicit MainLog(uint8_t id, Logger &log);
   void run() override;
 
@@ -39,7 +44,7 @@ class MainLog : public Thread {
 
   Logger &log_;
   System &sys_;
-  Data &data_;
+  data::Data &data_;
   std::array<NavigationVector, data::Sensors::kNumImus> gravity_calibration_;
 
   std::array<ImuDataLogger, data::Sensors::kNumImus> imu_loggers_;

--- a/src/navigation/main_log.hpp
+++ b/src/navigation/main_log.hpp
@@ -18,14 +18,6 @@
 
 namespace hyped {
 
-using data::ImuData;
-using data::NavigationVector;
-using navigation::ImuDataLogger;
-using utils::Logger;
-using utils::System;
-using utils::concurrent::Thread;
-using utils::math::OnlineStatistics;
-
 namespace navigation {
 
 class MainLog : public utils::concurrent::Thread {
@@ -36,18 +28,18 @@ class MainLog : public utils::concurrent::Thread {
    * @param id log ID
    * @param log Logger object
    */
-  explicit MainLog(uint8_t id, Logger &log);
+  explicit MainLog(uint8_t id, utils::Logger &log);
   void run() override;
 
  private:
   static constexpr int kNumCalibrationQueries = 10000;
 
-  Logger &log_;
-  System &sys_;
+  utils::Logger &log_;
+  utils::System &sys_;
   data::Data &data_;
-  std::array<NavigationVector, data::Sensors::kNumImus> gravity_calibration_;
+  std::array<data::NavigationVector, data::Sensors::kNumImus> gravity_calibration_;
 
-  std::array<ImuDataLogger, data::Sensors::kNumImus> imu_loggers_;
+  std::array<navigation::ImuDataLogger, data::Sensors::kNumImus> imu_loggers_;
 
   /**
    * @brief Determine the value of gravitational acceleration measured by sensors at rest

--- a/src/navigation/main_log.hpp
+++ b/src/navigation/main_log.hpp
@@ -26,9 +26,9 @@ class MainLog : public utils::concurrent::Thread {
    * @brief Construct a new Main Log object
    *
    * @param id log ID
-   * @param log Logger object
+   * @param log System logger
    */
-  explicit MainLog(uint8_t id, utils::Logger &log);
+  explicit MainLog(const uint8_t id, utils::Logger &log);
   void run() override;
 
  private:


### PR DESCRIPTION
Cleans `main_log.cpp `and `main_log.hpp`

## Changes
- changed `int` to `std::size_t` for loops
- removed `using`
- renamed `acc` to `acceleration`
- changed [i] to .at(i)
