### PR TITLE
State Machine fix for GPIO Manager

### DIFF
--- a/src/sensors/gpio_manager.cpp
+++ b/src/sensors/gpio_manager.cpp
@@ -78,6 +78,7 @@ void GpioManager::run()
         case data::State::kIdle:
         case data::State::kAccelerating:
         case data::State::kCruising:
+        case data::State::kCalibrating:
         case data::State::kNominalBraking:
           break;
         case data::State::kEmergencyBraking:


### PR DESCRIPTION
## Description
Resolves [#81](https://github.com/Hyp-ed/hyped-2022/issues/81)

## Changes
- Adds switch case for kCalibrating in GPIO Manager.