### PR TITLE
STM - adding PreBraking and Failure PreBraking

### DIFF
--- a/src/data/data.cpp
+++ b/src/data/data.cpp
@@ -8,8 +8,19 @@ using utils::concurrent::ScopedLock;
 namespace data {
 
 const char *states[num_states] = {
-  "Idle",           "PreCalibrating",   "Calibrating",    "Ready",    "Accelerating", "Cruising",
-  "NominalBraking", "EmergencyBraking", "FailureStopped", "Finished", "Invalid",
+  "Idle",
+  "PreCalibrating",
+  "Calibrating",
+  "Ready",
+  "Accelerating",
+  "Cruising",
+  "PreBraking",
+  "NominalBraking",
+  "FailurePreBraking",
+  "EmergencyBraking",
+  "FailureStopped",
+  "Finished",
+  "Invalid",
 };
 
 Data &Data::getInstance()

--- a/src/data/data.cpp
+++ b/src/data/data.cpp
@@ -8,19 +8,8 @@ using utils::concurrent::ScopedLock;
 namespace data {
 
 const char *states[num_states] = {
-  "Idle",
-  "PreCalibrating",
-  "Calibrating",
-  "Ready",
-  "Accelerating",
-  "Cruising",
-  "PreBraking",
-  "NominalBraking",
-  "FailurePreBraking",
-  "EmergencyBraking",
-  "FailureStopped",
-  "Finished",
-  "Invalid",
+  "Idle", "PreCalibrating", "Calibrating",  "Ready",  "Accelerating", "Cruising", "PreBraking",
+  "NominalBraking", "FailurePreBraking",  "EmergencyBraking", "FailureStopped", "Finished", "Invalid",
 };
 
 Data &Data::getInstance()

--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -82,6 +82,8 @@ struct Sensors : public Module {
   DataPoint<array<ImuData, kNumImus>> imu;
   DataPoint<array<EncoderData, kNumEncoders>> encoder;
   array<StripeCounter, kNumKeyence> keyence_stripe_counter;
+
+  bool HP_off = false;  // true if all SSRs are not in HP
 };
 
 struct BatteryData {
@@ -146,7 +148,9 @@ enum State {
   kReady,
   kAccelerating,
   kCruising,
+  kPreBraking,
   kNominalBraking,
+  kFailurePreBraking,
   kEmergencyBraking,
   kFailureStopped,
   kFinished,

--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -83,7 +83,7 @@ struct Sensors : public Module {
   DataPoint<array<EncoderData, kNumEncoders>> encoder;
   array<StripeCounter, kNumKeyence> keyence_stripe_counter;
 
-  bool HP_off = false;  // true if all SSRs are not in HP
+  bool high_power_off = false;  // true if all SSRs are not in HP
 };
 
 struct BatteryData {

--- a/src/sensors/gpio_manager.cpp
+++ b/src/sensors/gpio_manager.cpp
@@ -28,19 +28,25 @@ GpioManager::GpioManager(Logger &log)
 
 void GpioManager::clearHP()
 {
+  data::Sensors sensors_data_struct = data_.getSensorsData();
   master_->clear();  // important to clear this first
   for (int i = 0; i < data::Batteries::kNumHPBatteries; i++) {
     hp_ssr_[i]->clear();  // HP off until kReady State
   }
+  sensors_data_struct.HP_off = true;  // all SSRs in HP off
+  data_.setSensorsData(sensors_data_struct);
 }
 
 void GpioManager::setHP()
 {
+  data::Sensors sensors_data_struct = data_.getSensorsData();
   for (int i = 0; i < data::Batteries::kNumHPBatteries; i++) {
     hp_ssr_[i]->set();
     sleep(50);
   }
   master_->set();
+  sensors_data_struct.HP_off = false;  // all SSRs in HP on
+  data_.setSensorsData(sensors_data_struct);
 }
 
 void GpioManager::run()
@@ -79,7 +85,15 @@ void GpioManager::run()
         case data::State::kAccelerating:
         case data::State::kCruising:
         case data::State::kCalibrating:
+        case data::State::kPreBraking:
+          clearHP();
+          log_.ERR("GPIO-MANAGER", "Braking! HP SSR cleared");
+          break;
         case data::State::kNominalBraking:
+          break;
+        case data::State::kFailurePreBraking:
+          clearHP();
+          log_.ERR("GPIO-MANAGER", "Failure Braking! HP SSR cleared");
           break;
         case data::State::kEmergencyBraking:
         case data::State::kFailureStopped:

--- a/src/sensors/gpio_manager.cpp
+++ b/src/sensors/gpio_manager.cpp
@@ -33,7 +33,7 @@ void GpioManager::clearHP()
   for (int i = 0; i < data::Batteries::kNumHPBatteries; i++) {
     hp_ssr_[i]->clear();  // HP off until kReady State
   }
-  sensors_data_struct.HP_off = true;  // all SSRs in HP off
+  sensors_data_struct.high_power_off = true;  // all SSRs in HP off
   data_.setSensorsData(sensors_data_struct);
 }
 
@@ -45,7 +45,7 @@ void GpioManager::setHP()
     sleep(50);
   }
   master_->set();
-  sensors_data_struct.HP_off = false;  // all SSRs in HP on
+  sensors_data_struct.high_power_off = false;  // all SSRs in HP on
   data_.setSensorsData(sensors_data_struct);
 }
 

--- a/src/state_machine/state.cpp
+++ b/src/state_machine/state.cpp
@@ -126,7 +126,7 @@ State *Accelerating::checkTransition(Logger &log)
 
   bool emergency = checkEmergency(log, brakes_data_, nav_data_, batteries_data_, telemetry_data_,
                                   sensors_data_, motors_data_);
-  if (emergency) { return FailureBraking::getInstance(); }
+  if (emergency) { return FailurePreBraking::getInstance(); }
 
   bool in_braking_zone = checkEnteredBrakingZone(log, nav_data_);
   if (in_braking_zone) { return PreBraking::getInstance(); }
@@ -151,7 +151,7 @@ State *Cruising::checkTransition(Logger &log)
 
   bool emergency = checkEmergency(log, brakes_data_, nav_data_, batteries_data_, telemetry_data_,
                                   sensors_data_, motors_data_);
-  if (emergency) { return FailureBraking::getInstance(); }
+  if (emergency) { return FailurePreBraking::getInstance(); }
 
   bool in_braking_zone = checkEnteredBrakingZone(log, nav_data_);
   if (in_braking_zone) { return PreBraking::getInstance(); }
@@ -173,7 +173,7 @@ State *PreBraking::checkTransition(Logger &log)
 
   bool emergency = checkEmergency(log, brakes_data_, nav_data_, batteries_data_, telemetry_data_,
                                   sensors_data_, motors_data_);
-  if (emergency) { return FailureBraking::getInstance(); }
+  if (emergency) { return FailurePreBraking::getInstance(); }
 
   bool has_high_power_off = checkHighPowerOff(sensors_data_);
   if (has_high_power_off) { return NominalBraking::getInstance(); }
@@ -216,6 +216,23 @@ State *Finished::checkTransition(Logger &log)
 
   bool received_shutdown_command = checkShutdownCommand(telemetry_data_);
   if (received_shutdown_command) { return Off::getInstance(); }
+  return nullptr;
+}
+
+//--------------------------------------------------------------------------------------
+//  Failure Pre-Braking
+//--------------------------------------------------------------------------------------
+
+FailurePreBraking FailurePreBraking::instance_;
+data::State FailurePreBraking::enum_value_       = data::kFailurePreBraking;
+char FailurePreBraking::string_representation_[] = "FailurePreBraking";
+
+State *FailurePreBraking::checkTransition(Logger &log)
+{
+  updateModuleData();
+
+  bool has_high_power_off = checkHighPowerOff(sensors_data_);
+  if (has_high_power_off) { return FailureBraking::getInstance(); }
   return nullptr;
 }
 

--- a/src/state_machine/state.cpp
+++ b/src/state_machine/state.cpp
@@ -175,8 +175,8 @@ State *PreBraking::checkTransition(Logger &log)
                                   sensors_data_, motors_data_);
   if (emergency) { return FailureBraking::getInstance(); }
 
-  bool hp_off = checkHPOff(sensors_data_);
-  if (hp_off) { return NominalBraking::getInstance(); }
+  bool has_high_power_off = checkHighPowerOff(sensors_data_);
+  if (has_high_power_off) { return NominalBraking::getInstance(); }
   return nullptr;
 }
 

--- a/src/state_machine/state.cpp
+++ b/src/state_machine/state.cpp
@@ -129,7 +129,7 @@ State *Accelerating::checkTransition(Logger &log)
   if (emergency) { return FailureBraking::getInstance(); }
 
   bool in_braking_zone = checkEnteredBrakingZone(log, nav_data_);
-  if (in_braking_zone) { return NominalBraking::getInstance(); }
+  if (in_braking_zone) { return PreBraking::getInstance(); }
 
   bool reached_max_velocity = checkReachedMaxVelocity(log, nav_data_);
   if (reached_max_velocity) { return Cruising::getInstance(); }
@@ -154,8 +154,29 @@ State *Cruising::checkTransition(Logger &log)
   if (emergency) { return FailureBraking::getInstance(); }
 
   bool in_braking_zone = checkEnteredBrakingZone(log, nav_data_);
-  if (in_braking_zone) { return NominalBraking::getInstance(); }
+  if (in_braking_zone) { return PreBraking::getInstance(); }
 
+  return nullptr;
+}
+
+//--------------------------------------------------------------------------------------
+//  Pre-Braking
+//--------------------------------------------------------------------------------------
+
+PreBraking PreBraking::instance_;
+data::State PreBraking::enum_value_       = data::kPreBraking;
+char PreBraking::string_representation_[] = "PreBraking";
+
+State *PreBraking::checkTransition(Logger &log)
+{
+  updateModuleData();
+
+  bool emergency = checkEmergency(log, brakes_data_, nav_data_, batteries_data_, telemetry_data_,
+                                  sensors_data_, motors_data_);
+  if (emergency) { return FailureBraking::getInstance(); }
+
+  bool hp_off = checkHPOff(sensors_data_);
+  if (hp_off) { return NominalBraking::getInstance(); }
   return nullptr;
 }
 

--- a/src/state_machine/state.hpp
+++ b/src/state_machine/state.hpp
@@ -74,17 +74,19 @@ class Messages;
  * Generating structs for all the states
  */
 
-MAKE_STATE(Idle)            // State on startup
-MAKE_STATE(PreCalibrating)  // Sub-state between Idle and Calibrating
-MAKE_STATE(Calibrating)     // Calibrating starts after user input is given
-MAKE_STATE(Ready)           // After calibration has finished
-MAKE_STATE(Accelerating)    // First phase of the run
-MAKE_STATE(Cruising)        // Intermediate phase to not exceed maximum velocity
-MAKE_STATE(NominalBraking)  // Second phase of the run
-MAKE_STATE(Finished)        // State after the run
-MAKE_STATE(FailureBraking)  // Entered upon failure during the run
-MAKE_STATE(FailureStopped)  // Entered upon failure before the run or after
-                            // FailureBraking
+MAKE_STATE(Idle)               // State on startup
+MAKE_STATE(PreCalibrating)     // Sub-state between Idle and Calibrating
+MAKE_STATE(Calibrating)        // Calibrating starts after user input is given
+MAKE_STATE(Ready)              // After calibration has finished
+MAKE_STATE(Accelerating)       // First phase of the run
+MAKE_STATE(Cruising)           // Intermediate phase to not exceed maximum velocity
+MAKE_STATE(PreBraking)         // Sub-state between Accelerating/Cruising and Nominal Braking
+MAKE_STATE(NominalBraking)     // Second phase of the run
+MAKE_STATE(Finished)           // State after the run
+MAKE_STATE(FailurePreBraking)  // Sub-state entered before FailureBraking
+MAKE_STATE(FailureBraking)     // Entered upon failure during the run
+MAKE_STATE(FailureStopped)     // Entered upon failure before the run or after
+                               // FailureBraking
 
 #undef MAKE_STATE
 

--- a/src/state_machine/transitions.cpp
+++ b/src/state_machine/transitions.cpp
@@ -81,7 +81,7 @@ bool checkModulesReady(Logger &log, const data::EmergencyBrakes &brakes_data,
 // Sensors Command
 //--------------------------------------------------------------------------------------
 
-bool checkHPOff(const data::Sensors &sensors_data_struct)
+bool checkHighPowerOff(const data::Sensors &sensors_data_struct)
 {
   if (!sensors_data_struct.HP_off) return false;
 

--- a/src/state_machine/transitions.cpp
+++ b/src/state_machine/transitions.cpp
@@ -83,7 +83,7 @@ bool checkModulesReady(Logger &log, const data::EmergencyBrakes &brakes_data,
 
 bool checkHighPowerOff(const data::Sensors &sensors_data_struct)
 {
-  if (!sensors_data_struct.HP_off) return false;
+  if (!sensors_data_struct.high_power_off) return false;
 
   return true;
 }

--- a/src/state_machine/transitions.cpp
+++ b/src/state_machine/transitions.cpp
@@ -78,6 +78,17 @@ bool checkModulesReady(Logger &log, const data::EmergencyBrakes &brakes_data,
 }
 
 //--------------------------------------------------------------------------------------
+// Sensors Command
+//--------------------------------------------------------------------------------------
+
+bool checkHPOff(const data::Sensors &sensors_data_struct)
+{
+  if (!sensors_data_struct.HP_off) return false;
+
+  return true;
+}
+
+//--------------------------------------------------------------------------------------
 // Telemetry Commands
 //--------------------------------------------------------------------------------------
 

--- a/src/state_machine/transitions.hpp
+++ b/src/state_machine/transitions.hpp
@@ -60,7 +60,7 @@ bool checkModulesReady(Logger &log, const data::EmergencyBrakes &brakes_data,
 /*
  * @brief   Returns true iff all SSRs have HP off.
  */
-bool checkHPOff(const data::Sensors &sensors_data_struct);
+bool checkHighPowerOff(const data::Sensors &sensors_data_struct);
 
 //--------------------------------------------------------------------------------------
 // Telemetry Commands

--- a/src/state_machine/transitions.hpp
+++ b/src/state_machine/transitions.hpp
@@ -54,6 +54,15 @@ bool checkModulesReady(Logger &log, const data::EmergencyBrakes &brakes_data,
                        const data::Motors &motors_data);
 
 //--------------------------------------------------------------------------------------
+// Sensors Command
+//--------------------------------------------------------------------------------------
+
+/*
+ * @brief   Returns true iff all SSRs have HP off.
+ */
+bool checkHPOff(const data::Sensors &sensors_data_struct);
+
+//--------------------------------------------------------------------------------------
 // Telemetry Commands
 //--------------------------------------------------------------------------------------
 

--- a/test/state_machine/run.test.cpp
+++ b/test/state_machine/run.test.cpp
@@ -246,7 +246,7 @@ class RunTest : public Test {
     // Randomise data
     randomiseInternally();
 
-    // Prevent Idle -> FailureStopped
+    // Prevent PreCalibrating -> FailureStopped
     telemetry_data_.emergency_stop_command = false;
 
     // Enforce Idle -> PreCalibrating
@@ -291,8 +291,8 @@ class RunTest : public Test {
   }
 
   /**
-   * Modifies data such that the Idle -> FailureStopped transition conditions are met and verifies
-   * the behaviour.
+   * Modifies data such that the PreCalibrating -> FailureStopped transition conditions are met and
+   * verifies the behaviour.
    */
   void testPreCalibratingEmergency()
   {
@@ -305,7 +305,7 @@ class RunTest : public Test {
     // Randomise data
     randomiseInternally();
 
-    // Enforce Idle -> FailureStopped
+    // Enforce PreCalibrating -> FailureStopped
     forceEmergency();
 
     // Prevent FailureStopped -> Off
@@ -458,6 +458,7 @@ class RunTest : public Test {
 
     // Enforce Ready -> Accelerating
     telemetry_data_.launch_command = true;
+    sensors_data_.HP_off           = false;
 
     // Prevent Accelerating -> NominalBraking
     nav_data_.displacement     = 0;
@@ -472,12 +473,14 @@ class RunTest : public Test {
     const bool has_launch_command = checkLaunchCommand(telemetry_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_reached_max_velocity = checkReachedMaxVelocity(log_, nav_data_);
+    const bool has_hp_off               = checkHPOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(true, has_launch_command);
     ASSERT_EQ(false, has_entered_braking_zone);
     ASSERT_EQ(false, has_reached_max_velocity);
+    ASSERT_EQ(false, has_hp_off);
     disableOutput();
 
     // Let STM do its thing
@@ -537,10 +540,10 @@ class RunTest : public Test {
   }
 
   /**
-   * Modifies data such that the Accelerating -> NominalBraking transition conditions are met and
+   * Modifies data such that the Accelerating -> PreBraking transition conditions are met and
    * verifies the behaviour.
    */
-  void testAcceleratingToNominalBraking()
+  void testAcceleratingToPreBraking()
   {
     // Check initial state
     readData();
@@ -560,11 +563,10 @@ class RunTest : public Test {
     batteries_data_.module_status          = ModuleStatus::kReady;
     telemetry_data_.emergency_stop_command = false;
 
-    // Enforce Accelerating -> NominalBraking
-    nav_data_.braking_distance = 1000;
-    nav_data_.displacement     = Navigation::kRunLength - nav_data_.braking_distance;
+    // Prevent PreBraking -> NominalBraking
+    sensors_data_.HP_off = false;
 
-    // Prevent NominalBraking -> Finished
+    // Prevent PreBraking -> Finished
     nav_data_.velocity = 100;
 
     // Verify transition conditions are as intended
@@ -572,11 +574,13 @@ class RunTest : public Test {
                                               telemetry_data_, sensors_data_, motors_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_stopped              = checkPodStopped(log_, nav_data_);
+    const bool has_hp_off               = checkHPOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(true, has_entered_braking_zone);
     ASSERT_EQ(false, has_stopped);
+    ASSERT_EQ(false, has_hp_off);
     disableOutput();
 
     // Let STM do its thing
@@ -587,8 +591,8 @@ class RunTest : public Test {
     // Check result
     enableOutput();
     ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in Accelerating";
-    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kNominalBraking)
-      << "failed to transition from Accelerating to NominalBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kPreBraking)
+      << "failed to transition from Accelerating to PreBraking";
     disableOutput();
   }
 
@@ -616,6 +620,9 @@ class RunTest : public Test {
     batteries_data_.module_status          = ModuleStatus::kReady;
     telemetry_data_.emergency_stop_command = false;
 
+    // Prevent Cruising -> NominalBraking
+    sensors_data_.HP_off = false;
+
     // Prevent Accelerating -> NominalBraking
     // Prevent Cruising -> NominalBraking
     nav_data_.braking_distance = 0;
@@ -629,11 +636,13 @@ class RunTest : public Test {
                                               telemetry_data_, sensors_data_, motors_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_reached_max_velocity = checkReachedMaxVelocity(log_, nav_data_);
+    const bool has_hp_off               = checkHPOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(false, has_entered_braking_zone);
     ASSERT_EQ(true, has_reached_max_velocity);
+    ASSERT_EQ(false, has_hp_off);
     disableOutput();
 
     // Let STM do its thing
@@ -693,7 +702,11 @@ class RunTest : public Test {
     disableOutput();
   }
 
-  void testCruisingToNominalBraking()
+  /**
+   * Modifies data_ such that the Cruising -> PreBraking transition conditions are met and
+   * verifies the behaviour.
+   */
+  void testCruisingToPreBraking()
   {
     // Check initial state
     readData();
@@ -713,11 +726,10 @@ class RunTest : public Test {
     batteries_data_.module_status          = ModuleStatus::kReady;
     telemetry_data_.emergency_stop_command = false;
 
-    // Enforce Cruising -> NominalBraking
-    nav_data_.braking_distance = 1000;
-    nav_data_.displacement     = Navigation::kRunLength - nav_data_.braking_distance;
+    // Prevent PreBraking -> NominalBraking
+    sensors_data_.HP_off = false;
 
-    // Prevent NominalBraking -> Finished
+    // Prevent PreBraking -> Finished
     nav_data_.velocity = 100;
 
     // Verify transition conditions are as intended
@@ -725,11 +737,13 @@ class RunTest : public Test {
                                               telemetry_data_, sensors_data_, motors_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_stopped              = checkPodStopped(log_, nav_data_);
+    const bool has_hp_off               = checkHPOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(true, has_entered_braking_zone);
     ASSERT_EQ(false, has_stopped);
+    ASSERT_EQ(false, has_hp_off);
     disableOutput();
 
     // Let STM do its thing
@@ -740,11 +754,15 @@ class RunTest : public Test {
     // Check result
     enableOutput();
     ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in Cruising";
-    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kNominalBraking)
-      << "failed to transition from Cruising to NominalBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kPreBraking)
+      << "failed to transition from Cruising to PreBraking";
     disableOutput();
   }
 
+  /**
+   * Modifies data_ such that the Cruising-> FailureBraking transition conditions are met and
+   * verifies the behaviour.
+   */
   void testCruisingEmergency()
   {
     // Check initial state
@@ -782,6 +800,109 @@ class RunTest : public Test {
     ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in Cruising";
     ASSERT_EQ(stm_data_.current_state, hyped::data::State::kEmergencyBraking)
       << "failed to transition from Cruising to EmergencyBraking";
+    disableOutput();
+  }
+
+  /**
+   * Modifies data_ such that the PreBraking-> FailureBraking transition conditions are met and
+   * verifies the behaviour.
+   */
+  void testPreBrakingEmergency()
+  {
+    // Check initial state
+    readData();
+    enableOutput();
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kPreBraking);
+    disableOutput();
+
+    // Randomise data
+    randomiseInternally();
+
+    // Enforce PreBraking -> FailureBraking
+    forceEmergency();
+
+    // Prevent FailureBraking -> FailureStopped
+    nav_data_.velocity = 100;
+
+    // Verify transition conditions are as intended
+    const bool has_emergency = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
+                                              telemetry_data_, sensors_data_, motors_data_);
+    const bool has_stopped   = checkPodStopped(log_, nav_data_);
+
+    enableOutput();
+    ASSERT_EQ(true, has_emergency);
+    ASSERT_EQ(false, has_stopped);
+    disableOutput();
+
+    // Let STM do its thing
+    writeData();
+    waitForUpdate();
+    readData();
+
+    // Check result
+    enableOutput();
+    ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in PreBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kEmergencyBraking)
+      << "failed to transition from PreBraking to EmergencyBraking";
+    disableOutput();
+  }
+
+  /**
+   * Modifies data_ such that the PreBraking -> NominalBraking transition conditions are met and
+   * verifies the behaviour.
+   */
+  void testPreBrakingToNominalBraking()
+  {
+    // Check initial state
+    readData();
+    enableOutput();
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kPreBraking);
+    disableOutput();
+
+    // Randomise data
+    randomiseInternally();
+
+    // Prevent PreBraking -> FailureBraking
+    brakes_data_.module_status             = ModuleStatus::kReady;
+    nav_data_.module_status                = ModuleStatus::kReady;
+    telemetry_data_.module_status          = ModuleStatus::kReady;
+    motors_data_.module_status             = ModuleStatus::kReady;
+    sensors_data_.module_status            = ModuleStatus::kReady;
+    batteries_data_.module_status          = ModuleStatus::kReady;
+    telemetry_data_.emergency_stop_command = false;
+
+    // Enforce PreBraking -> NominalBraking
+    nav_data_.braking_distance = 1000;
+    nav_data_.displacement     = Navigation::kRunLength - nav_data_.braking_distance;
+    sensors_data_.HP_off       = true;
+
+    // Prevent NominalBraking -> Finished
+    nav_data_.velocity = 100;
+
+    // Verify transition conditions are as intended
+    const bool has_emergency = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
+                                              telemetry_data_, sensors_data_, motors_data_);
+    const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
+    const bool has_stopped              = checkPodStopped(log_, nav_data_);
+    const bool has_hp_off               = checkHPOff(sensors_data_);
+
+    enableOutput();
+    ASSERT_EQ(false, has_emergency);
+    ASSERT_EQ(true, has_entered_braking_zone);
+    ASSERT_EQ(false, has_stopped);
+    ASSERT_EQ(true, has_hp_off);
+    disableOutput();
+
+    // Let STM do its thing
+    writeData();
+    waitForUpdate();
+    readData();
+
+    // Check result
+    enableOutput();
+    ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in PreBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kNominalBraking)
+      << "failed to transition from PreBraking to NominalBraking";
     disableOutput();
   }
 
@@ -1021,7 +1142,8 @@ TEST_F(RunTest, nominalRunWithoutCruising)
     testPreCalibratingToCalibrating();
     testCalibratingToReady();
     testReadyToAccelerating();
-    testAcceleratingToNominalBraking();
+    testAcceleratingToPreBraking();
+    testPreBrakingToNominalBraking();
     testNominalBrakingToFinished();
     testFinishedToOff();
 
@@ -1051,7 +1173,8 @@ TEST_F(RunTest, nominalRunWithCruising)
     testCalibratingToReady();
     testReadyToAccelerating();
     testAcceleratingToCruising();
-    testCruisingToNominalBraking();
+    testCruisingToPreBraking();
+    testPreBrakingToNominalBraking();
     testNominalBrakingToFinished();
     testFinishedToOff();
 
@@ -1205,7 +1328,6 @@ TEST_F(RunTest, brakingEmergencyWithoutCruising)
   for (int i = 0; i < kTestSize; i++) {
     utils::System &sys = utils::System::getSystem();
     sys.running_       = true;
-
     initialiseData();
 
     Thread *state_machine = new Main(0, log_);
@@ -1217,7 +1339,8 @@ TEST_F(RunTest, brakingEmergencyWithoutCruising)
     testPreCalibratingToCalibrating();
     testCalibratingToReady();
     testReadyToAccelerating();
-    testAcceleratingToNominalBraking();
+    testAcceleratingToPreBraking();
+    testPreBrakingToNominalBraking();
     testNominalBrakingEmergency();
     testFailureBrakingToStopped();
     testFailureStoppedToOff();
@@ -1249,7 +1372,8 @@ TEST_F(RunTest, brakingEmergencyWithCruising)
     testCalibratingToReady();
     testReadyToAccelerating();
     testAcceleratingToCruising();
-    testCruisingToNominalBraking();
+    testCruisingToPreBraking();
+    testPreBrakingToNominalBraking();
     testNominalBrakingEmergency();
     testFailureBrakingToStopped();
     testFailureStoppedToOff();

--- a/test/state_machine/run.test.cpp
+++ b/test/state_machine/run.test.cpp
@@ -458,7 +458,7 @@ class RunTest : public Test {
 
     // Enforce Ready -> Accelerating
     telemetry_data_.launch_command = true;
-    sensors_data_.HP_off           = false;
+    sensors_data_.high_power_off   = false;
 
     // Prevent Accelerating -> NominalBraking
     nav_data_.displacement     = 0;
@@ -564,7 +564,7 @@ class RunTest : public Test {
     telemetry_data_.emergency_stop_command = false;
 
     // Prevent PreBraking -> NominalBraking
-    sensors_data_.HP_off = false;
+    sensors_data_.high_power_off = false;
 
     // Prevent PreBraking -> Finished
     nav_data_.velocity = 100;
@@ -621,7 +621,7 @@ class RunTest : public Test {
     telemetry_data_.emergency_stop_command = false;
 
     // Prevent Cruising -> NominalBraking
-    sensors_data_.HP_off = false;
+    sensors_data_.high_power_off = false;
 
     // Prevent Accelerating -> NominalBraking
     // Prevent Cruising -> NominalBraking
@@ -659,8 +659,8 @@ class RunTest : public Test {
   }
 
   /**
-   * Modifies data_ such that the Accelerating -> FailureBraking transition conditions are met and
-   * verifies the behaviour.
+   * Modifies data_ such that the Accelerating -> FailurePreBraking transition conditions are met
+   * and verifies the behaviour.
    */
   void testAcceleratingEmergency()
   {
@@ -673,20 +673,22 @@ class RunTest : public Test {
     // Randomise data
     randomiseInternally();
 
-    // Enforce Accelerating -> FailureBraking
+    // Enforce Accelerating -> FailurePreBraking
     forceEmergency();
 
-    // Prevent FailureBraking -> FailureStopped
+    // Prevent FailurePreBraking -> FailureStopped
     nav_data_.velocity = 100;
 
     // Verify transition conditions are as intended
-    const bool has_emergency = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
+    const bool has_emergency      = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
                                               telemetry_data_, sensors_data_, motors_data_);
-    const bool has_stopped   = checkPodStopped(log_, nav_data_);
+    const bool has_stopped        = checkPodStopped(log_, nav_data_);
+    const bool has_high_power_off = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(true, has_emergency);
     ASSERT_EQ(false, has_stopped);
+    ASSERT_EQ(false, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing
@@ -697,8 +699,8 @@ class RunTest : public Test {
     // Check result
     enableOutput();
     ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in Accelerating";
-    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kEmergencyBraking)
-      << "failed to transition from Accelerating to EmergencyBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kFailurePreBraking)
+      << "failed to transition from Accelerating to FailurePreBraking";
     disableOutput();
   }
 
@@ -727,7 +729,7 @@ class RunTest : public Test {
     telemetry_data_.emergency_stop_command = false;
 
     // Prevent PreBraking -> NominalBraking
-    sensors_data_.HP_off = false;
+    sensors_data_.high_power_off = false;
 
     // Prevent PreBraking -> Finished
     nav_data_.velocity = 100;
@@ -760,7 +762,7 @@ class RunTest : public Test {
   }
 
   /**
-   * Modifies data_ such that the Cruising-> FailureBraking transition conditions are met and
+   * Modifies data_ such that the Cruising-> FailurePreBraking transition conditions are met and
    * verifies the behaviour.
    */
   void testCruisingEmergency()
@@ -774,20 +776,22 @@ class RunTest : public Test {
     // Randomise data
     randomiseInternally();
 
-    // Enforce Cruising -> FailureBraking
+    // Enforce Cruising -> FailurePreBraking
     forceEmergency();
 
-    // Prevent FailureBraking -> FailureStopped
+    // Prevent FailurePreBraking -> FailureStopped
     nav_data_.velocity = 100;
 
     // Verify transition conditions are as intended
-    const bool has_emergency = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
+    const bool has_emergency      = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
                                               telemetry_data_, sensors_data_, motors_data_);
-    const bool has_stopped   = checkPodStopped(log_, nav_data_);
+    const bool has_stopped        = checkPodStopped(log_, nav_data_);
+    const bool has_high_power_off = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(true, has_emergency);
     ASSERT_EQ(false, has_stopped);
+    ASSERT_EQ(false, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing
@@ -798,13 +802,13 @@ class RunTest : public Test {
     // Check result
     enableOutput();
     ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in Cruising";
-    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kEmergencyBraking)
-      << "failed to transition from Cruising to EmergencyBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kFailurePreBraking)
+      << "failed to transition from Cruising to FailurePreBraking";
     disableOutput();
   }
 
   /**
-   * Modifies data_ such that the PreBraking-> FailureBraking transition conditions are met and
+   * Modifies data_ such that the PreBraking-> FailurePreBraking transition conditions are met and
    * verifies the behaviour.
    */
   void testPreBrakingEmergency()
@@ -818,20 +822,22 @@ class RunTest : public Test {
     // Randomise data
     randomiseInternally();
 
-    // Enforce PreBraking -> FailureBraking
+    // Enforce PreBraking -> FailurePreBraking
     forceEmergency();
 
-    // Prevent FailureBraking -> FailureStopped
+    // Prevent FailurePreBraking -> FailureStopped
     nav_data_.velocity = 100;
 
     // Verify transition conditions are as intended
-    const bool has_emergency = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
+    const bool has_emergency      = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
                                               telemetry_data_, sensors_data_, motors_data_);
-    const bool has_stopped   = checkPodStopped(log_, nav_data_);
+    const bool has_stopped        = checkPodStopped(log_, nav_data_);
+    const bool has_high_power_off = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(true, has_emergency);
     ASSERT_EQ(false, has_stopped);
+    ASSERT_EQ(false, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing
@@ -842,8 +848,8 @@ class RunTest : public Test {
     // Check result
     enableOutput();
     ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in PreBraking";
-    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kEmergencyBraking)
-      << "failed to transition from PreBraking to EmergencyBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kFailurePreBraking)
+      << "failed to transition from PreBraking to FailurePreBraking";
     disableOutput();
   }
 
@@ -872,9 +878,9 @@ class RunTest : public Test {
     telemetry_data_.emergency_stop_command = false;
 
     // Enforce PreBraking -> NominalBraking
-    nav_data_.braking_distance = 1000;
-    nav_data_.displacement     = Navigation::kRunLength - nav_data_.braking_distance;
-    sensors_data_.HP_off       = true;
+    nav_data_.braking_distance   = 1000;
+    nav_data_.displacement       = Navigation::kRunLength - nav_data_.braking_distance;
+    sensors_data_.high_power_off = true;
 
     // Prevent NominalBraking -> Finished
     nav_data_.velocity = 100;
@@ -1039,6 +1045,49 @@ class RunTest : public Test {
     enableOutput();
     utils::System &sys = utils::System::getSystem();
     ASSERT_EQ(sys.running_, false) << "failed to transition from Finished to Off";
+    disableOutput();
+  }
+
+  /**
+   * Modifies data_ such that the FailurePreBraking-> FailureBraking transition conditions are met
+   * and verifies the behaviour.
+   */
+  void testFailurePreBrakingToFailureBraking()
+  {
+    // Check initial state
+    readData();
+    enableOutput();
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kFailurePreBraking);
+    disableOutput();
+
+    // Randomise data
+    randomiseInternally();
+
+    // Prevent FailureBraking -> FailureStopped
+    nav_data_.velocity = 100;
+
+    // Enforce FailurePreBraking -> FailureBraking
+    sensors_data_.high_power_off = true;
+
+    // Verify transition conditions are as intended
+    const bool has_stopped        = checkPodStopped(log_, nav_data_);
+    const bool has_high_power_off = checkHighPowerOff(sensors_data_);
+
+    enableOutput();
+    ASSERT_EQ(false, has_stopped);
+    ASSERT_EQ(true, has_high_power_off);
+    disableOutput();
+
+    // Let STM do its thing
+    writeData();
+    waitForUpdate();
+    readData();
+
+    // Check result
+    enableOutput();
+    ASSERT_EQ(stm_data_.critical_failure, false) << "encountered failure in FailurePreBraking";
+    ASSERT_EQ(stm_data_.current_state, hyped::data::State::kEmergencyBraking)
+      << "failed to transition from FailurePreBraking to FailureBraking";
     disableOutput();
   }
 
@@ -1281,6 +1330,7 @@ TEST_F(RunTest, acceleratingEmergency)
     testCalibratingToReady();
     testReadyToAccelerating();
     testAcceleratingEmergency();
+    testFailurePreBrakingToFailureBraking();
     testFailureBrakingToStopped();
     testFailureStoppedToOff();
 
@@ -1311,6 +1361,7 @@ TEST_F(RunTest, cruisingEmergency)
     testReadyToAccelerating();
     testAcceleratingToCruising();
     testCruisingEmergency();
+    testFailurePreBrakingToFailureBraking();
     testFailureBrakingToStopped();
     testFailureStoppedToOff();
 

--- a/test/state_machine/run.test.cpp
+++ b/test/state_machine/run.test.cpp
@@ -473,14 +473,14 @@ class RunTest : public Test {
     const bool has_launch_command = checkLaunchCommand(telemetry_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_reached_max_velocity = checkReachedMaxVelocity(log_, nav_data_);
-    const bool has_hp_off               = checkHPOff(sensors_data_);
+    const bool has_high_power_off       = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(true, has_launch_command);
     ASSERT_EQ(false, has_entered_braking_zone);
     ASSERT_EQ(false, has_reached_max_velocity);
-    ASSERT_EQ(false, has_hp_off);
+    ASSERT_EQ(false, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing
@@ -574,13 +574,13 @@ class RunTest : public Test {
                                               telemetry_data_, sensors_data_, motors_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_stopped              = checkPodStopped(log_, nav_data_);
-    const bool has_hp_off               = checkHPOff(sensors_data_);
+    const bool has_high_power_off       = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(true, has_entered_braking_zone);
     ASSERT_EQ(false, has_stopped);
-    ASSERT_EQ(false, has_hp_off);
+    ASSERT_EQ(false, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing
@@ -636,13 +636,13 @@ class RunTest : public Test {
                                               telemetry_data_, sensors_data_, motors_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_reached_max_velocity = checkReachedMaxVelocity(log_, nav_data_);
-    const bool has_hp_off               = checkHPOff(sensors_data_);
+    const bool has_high_power_off       = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(false, has_entered_braking_zone);
     ASSERT_EQ(true, has_reached_max_velocity);
-    ASSERT_EQ(false, has_hp_off);
+    ASSERT_EQ(false, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing
@@ -737,13 +737,13 @@ class RunTest : public Test {
                                               telemetry_data_, sensors_data_, motors_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_stopped              = checkPodStopped(log_, nav_data_);
-    const bool has_hp_off               = checkHPOff(sensors_data_);
+    const bool has_high_power_off       = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(true, has_entered_braking_zone);
     ASSERT_EQ(false, has_stopped);
-    ASSERT_EQ(false, has_hp_off);
+    ASSERT_EQ(false, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing
@@ -884,13 +884,13 @@ class RunTest : public Test {
                                               telemetry_data_, sensors_data_, motors_data_);
     const bool has_entered_braking_zone = checkEnteredBrakingZone(log_, nav_data_);
     const bool has_stopped              = checkPodStopped(log_, nav_data_);
-    const bool has_hp_off               = checkHPOff(sensors_data_);
+    const bool has_high_power_off       = checkHighPowerOff(sensors_data_);
 
     enableOutput();
     ASSERT_EQ(false, has_emergency);
     ASSERT_EQ(true, has_entered_braking_zone);
     ASSERT_EQ(false, has_stopped);
-    ASSERT_EQ(true, has_hp_off);
+    ASSERT_EQ(true, has_high_power_off);
     disableOutput();
 
     // Let STM do its thing

--- a/test/state_machine/state.test.cpp
+++ b/test/state_machine/state.test.cpp
@@ -412,7 +412,7 @@ TEST_F(AcceleratingTest, handlesInBrakingZone)
  * Time complexity: O(kTestSize)
  */
 
-/* TEST_F(AcceleratingTest, handlesReachedMaxVelocity)
+TEST_F(AcceleratingTest, handlesReachedMaxVelocity)
 {
   for (int i = 0; i < kTestSize; i++) {
     randomiseData();
@@ -421,11 +421,12 @@ TEST_F(AcceleratingTest, handlesInBrakingZone)
                                               telemetry_data_, sensors_data_, motors_data_);
 
     if (!has_emergency) {
+      const bool in_braking_zone      = checkEnteredBrakingZone(log_, nav_data_);
       const bool reached_max_velocity = checkReachedMaxVelocity(log_, nav_data_);
       const auto new_state            = state->checkTransition(log_);
 
       enableOutput();
-      if (reached_max_velocity) {
+      if (reached_max_velocity && !(in_braking_zone)) {
         ASSERT_EQ(new_state, Cruising::getInstance())
           << "failed to enter Cruising from Accelerating";
       } else {
@@ -435,7 +436,7 @@ TEST_F(AcceleratingTest, handlesInBrakingZone)
       disableOutput();
     }
   }
-} */
+}
 
 //---------------------------------------------------------------------------
 // Cruising Tests

--- a/test/state_machine/state.test.cpp
+++ b/test/state_machine/state.test.cpp
@@ -440,7 +440,7 @@ TEST_F(AcceleratingTest, handlesReachedMaxVelocity)
       enableOutput();
       if (reached_max_velocity) {
         ASSERT_EQ(new_state, Cruising::getInstance())
-          << "failed to enter Cruising from Accelerating ";
+          << "failed to enter Cruising from Accelerating";
       } else {
         ASSERT_NE(new_state, Cruising::getInstance())
           << "falsely entered Cruising from Accelerating";

--- a/test/state_machine/state.test.cpp
+++ b/test/state_machine/state.test.cpp
@@ -558,11 +558,11 @@ TEST_F(PreBrakingTest, handlesHPOff)
                                               telemetry_data_, sensors_data_, motors_data_);
 
     if (!has_emergency) {
-      const bool HP_off    = checkHPOff(sensors_data_);
-      const auto new_state = state->checkTransition(log_);
+      const bool has_high_power_off = checkHighPowerOff(sensors_data_);
+      const auto new_state          = state->checkTransition(log_);
 
       enableOutput();
-      if (HP_off) {
+      if (has_high_power_off) {
         ASSERT_EQ(new_state, NominalBraking::getInstance())
           << "failed to enter NominalBraking from PreBraking";
       } else {

--- a/test/state_machine/state.test.cpp
+++ b/test/state_machine/state.test.cpp
@@ -417,6 +417,18 @@ TEST_F(AcceleratingTest, handlesReachedMaxVelocity)
   for (int i = 0; i < kTestSize; i++) {
     randomiseData();
 
+    // Assert not in braking zone
+    nav_data_.braking_distance = 0;
+    nav_data_.displacement     = 0;
+
+    // Enforce Accelerating -> Cruising
+    nav_data_.velocity = Navigation::kMaximumVelocity;
+
+    // reading and writing to the CDS directly to update navigation data
+    Data &data_ = Data::getInstance();
+    data_.setNavigationData(nav_data_);
+    auto navigation_data = data_.getNavigationData();
+
     const bool has_emergency = checkEmergency(log_, brakes_data_, nav_data_, batteries_data_,
                                               telemetry_data_, sensors_data_, motors_data_);
 
@@ -426,9 +438,9 @@ TEST_F(AcceleratingTest, handlesReachedMaxVelocity)
       const auto new_state            = state->checkTransition(log_);
 
       enableOutput();
-      if (reached_max_velocity && !(in_braking_zone)) {
+      if (reached_max_velocity) {
         ASSERT_EQ(new_state, Cruising::getInstance())
-          << "failed to enter Cruising from Accelerating";
+          << "failed to enter Cruising from Accelerating ";
       } else {
         ASSERT_NE(new_state, Cruising::getInstance())
           << "falsely entered Cruising from Accelerating";

--- a/test/state_machine/state.test.cpp
+++ b/test/state_machine/state.test.cpp
@@ -347,7 +347,7 @@ struct AcceleratingTest : public StateTest {
 
 /**
  * Ensures that if any module reports an emergency,
- * the state changes to FailureBraking.
+ * the state changes to FailurePreBraking.
  *
  * Time complexity: O(kTestSize)
  */
@@ -362,11 +362,11 @@ TEST_F(AcceleratingTest, handlesEmergency)
 
     enableOutput();
     if (has_emergency) {
-      ASSERT_EQ(new_state, FailureBraking::getInstance())
-        << "failed to enter FailureBraking from Accelerating";
+      ASSERT_EQ(new_state, FailurePreBraking::getInstance())
+        << "failed to enter FailurePreBraking from Accelerating";
     } else {
-      ASSERT_NE(new_state, FailureBraking::getInstance())
-        << "falsely entered FailureBraking from Accelerating";
+      ASSERT_NE(new_state, FailurePreBraking::getInstance())
+        << "falsely entered FailurePreBraking from Accelerating";
     }
     disableOutput();
   }
@@ -410,8 +410,9 @@ TEST_F(AcceleratingTest, handlesInBrakingZone)
  * Cruising state.
  *
  * Time complexity: O(kTestSize)
+ */
 
-TEST_F(AcceleratingTest, handlesReachedMaxVelocity)
+/* TEST_F(AcceleratingTest, handlesReachedMaxVelocity)
 {
   for (int i = 0; i < kTestSize; i++) {
     randomiseData();
@@ -449,7 +450,7 @@ struct CruisingTest : public StateTest {
 
 /**
  * Ensures that if any module reports an emergency,
- * the state changes to FailureBraking.
+ * the state changes to FailurePreBraking.
  *
  * Time complexity: O(kTestSize)
  */
@@ -464,11 +465,11 @@ TEST_F(CruisingTest, handlesEmergency)
 
     enableOutput();
     if (has_emergency) {
-      ASSERT_EQ(new_state, FailureBraking::getInstance())
-        << "failed to enter FailureBraking from Cruising";
+      ASSERT_EQ(new_state, FailurePreBraking::getInstance())
+        << "failed to enter FailurePreBraking from Cruising";
     } else {
-      ASSERT_NE(new_state, FailureBraking::getInstance())
-        << "falsely entered FailureBraking from Cruising";
+      ASSERT_NE(new_state, FailurePreBraking::getInstance())
+        << "falsely entered FailurePreBraking from Cruising";
     }
     disableOutput();
   }
@@ -518,7 +519,7 @@ struct PreBrakingTest : public StateTest {
 
 /**
  * Ensures that if any module reports an emergency,
- * the state changes to FailureBraking.
+ * the state changes to FailurePreBraking.
  *
  * Time complexity: O(kTestSize)
  */
@@ -533,11 +534,11 @@ TEST_F(PreBrakingTest, handlesEmergency)
 
     enableOutput();
     if (has_emergency) {
-      ASSERT_EQ(new_state, FailureBraking::getInstance())
-        << "failed to enter FailureBraking from PreBraking";
+      ASSERT_EQ(new_state, FailurePreBraking::getInstance())
+        << "failed to enter FailurePreBraking from PreBraking";
     } else {
-      ASSERT_NE(new_state, FailureBraking::getInstance())
-        << "falsely entered FailureBraking from PreBraking";
+      ASSERT_NE(new_state, FailurePreBraking::getInstance())
+        << "falsely entered FailurePreBraking from PreBraking";
     }
     disableOutput();
   }
@@ -549,7 +550,7 @@ TEST_F(PreBrakingTest, handlesEmergency)
  *
  * Time complexity: O(kTestSize)
  */
-TEST_F(PreBrakingTest, handlesHPOff)
+TEST_F(PreBrakingTest, handlesHighPowerOff)
 {
   for (int i = 0; i < kTestSize; i++) {
     randomiseData();
@@ -673,6 +674,43 @@ TEST_F(FinishedTest, handlesShutdownCommand)
       ASSERT_EQ(new_state, Off::getInstance()) << "failed to enter Off from Finished";
     } else {
       ASSERT_NE(new_state, Off::getInstance()) << "falsely entered Off from Finished";
+    }
+    disableOutput();
+  }
+}
+
+//---------------------------------------------------------------------------
+// Failure Pre-Braking Tests
+//---------------------------------------------------------------------------
+
+/**
+ * Testing failure pre-braking behaviour with respect to data
+ */
+struct FailurePreBrakingTest : public StateTest {
+  FailurePreBraking *state = FailurePreBraking::getInstance();
+};
+
+/**
+ * Ensures that if SSRs are not in HP while in the failure
+ * pre-braking state, the state changes to FailureBraking.
+ *
+ * Time complexity: O(kTestSize)
+ */
+TEST_F(FailurePreBrakingTest, handlesHighPowerOff)
+{
+  for (int i = 0; i < kTestSize; i++) {
+    randomiseData();
+
+    const bool has_high_power_off = checkHighPowerOff(sensors_data_);
+    const auto new_state          = state->checkTransition(log_);
+
+    enableOutput();
+    if (has_high_power_off) {
+      ASSERT_EQ(new_state, FailureBraking::getInstance())
+        << "failed to enter FailureBraking from FailurePreBraking";
+    } else {
+      ASSERT_NE(new_state, FailureBraking::getInstance())
+        << "falsely entered FailureBraking from FailurePreBraking";
     }
     disableOutput();
   }


### PR DESCRIPTION
## Description
Adds the new sub-states of PreBraking and Failure PreBraking. 

## Changes
- data.cpp                 -> added new states to the array 
- data.hpp                 -> added new states to the enum and a boolean to track all SSRs state
- gpio_manager.cpp -> added new  states to the switch statement. setHP and clearHP now help track the state of all SSRs
- state.cpp                -> added PreBraking and FailurePreBraking
- state.hpp                -> added both sub-states
- transitions.[c/h]pp  -> added new function to retrieve SSR state from the CDS
- run.test.cpp            -> added/modified tests to accommodate PreBraking and FailurePreBraking
- state.test.cpp          -> added/modified tests to accommodate PreBraking and FailurePreBraking + added tests for Cruising 
