### PR TITLE
Refactor telemetry tests

### DIFF
--- a/test/telemetry/writer_convert_module_status.test.cpp
+++ b/test/telemetry/writer_convert_module_status.test.cpp
@@ -11,12 +11,6 @@ using namespace hyped::data;
  * Tests the conversion of Module Status from Enum to String as required for GUI
  */
 struct WriterConvertModuleStatus : public ::testing::Test {
-  // ---- Error messages -------
-  const std::string start_status_error            = "Should convert Start status.";
-  const std::string init_status_error             = "Should convert Init status.";
-  const std::string ready_status_error            = "Should convert Ready status.";
-  const std::string critical_failure_status_error = "Should convert Critical Failure status.";
-
  protected:
   void SetUp() {}
   void TearDown() {}
@@ -25,23 +19,23 @@ struct WriterConvertModuleStatus : public ::testing::Test {
 TEST_F(WriterConvertModuleStatus, convertsStartStatus)
 {
   std::string convertedModuleStatus = Writer::convertModuleStatus(ModuleStatus::kStart);
-  ASSERT_EQ(convertedModuleStatus, "START") << start_status_error;
+  ASSERT_EQ(convertedModuleStatus, "START") << "Should convert Start status.";
 }
 
 TEST_F(WriterConvertModuleStatus, convertsInitStatus)
 {
   std::string convertedModuleStatus = Writer::convertModuleStatus(ModuleStatus::kInit);
-  ASSERT_EQ(convertedModuleStatus, "INIT") << init_status_error;
+  ASSERT_EQ(convertedModuleStatus, "INIT") << "Should convert Init status.";
 }
 
 TEST_F(WriterConvertModuleStatus, convertsReadyStatus)
 {
   std::string convertedModuleStatus = Writer::convertModuleStatus(ModuleStatus::kReady);
-  ASSERT_EQ(convertedModuleStatus, "READY") << ready_status_error;
+  ASSERT_EQ(convertedModuleStatus, "READY") << "Should convert Ready status.";
 }
 
 TEST_F(WriterConvertModuleStatus, convertsCriticalFailureState)
 {
   std::string convertedModuleStatus = Writer::convertModuleStatus(ModuleStatus::kCriticalFailure);
-  ASSERT_EQ(convertedModuleStatus, "CRITICAL_FAILURE") << critical_failure_status_error;
+  ASSERT_EQ(convertedModuleStatus, "CRITICAL_FAILURE") << "Should convert Critical Failure status.";
 }

--- a/test/telemetry/writer_convert_state_machine_state.test.cpp
+++ b/test/telemetry/writer_convert_state_machine_state.test.cpp
@@ -11,18 +11,6 @@ using namespace hyped::data;
  * Tests the conversion of State from Enum to String as required for GUI
  */
 struct WriterConvertStateMachineState : public ::testing::Test {
-  // ---- Error messages -------
-  const std::string idle_state_error              = "Should convert Idle state.";
-  const std::string calibrating_state_error       = "Should convert Calibrating state.";
-  const std::string ready_state_error             = "Should convert Ready state.";
-  const std::string accelerating_state_error      = "Should convert Accelerating state.";
-  const std::string cruising_state_error          = "Should convert Cruising state.";
-  const std::string nominal_braking_state_error   = "Should convert Nominal Braking state.";
-  const std::string emergency_braking_state_error = "Should convert Emergency Braking state.";
-  const std::string failure_stopped_state_error   = "Should convert Failure Stopped state.";
-  const std::string finished_state_error          = "Should convert Finished state.";
-  const std::string invalid_state_error           = "Should convert Invalid state.";
-
  protected:
   void SetUp() {}
   void TearDown() {}
@@ -31,59 +19,59 @@ struct WriterConvertStateMachineState : public ::testing::Test {
 TEST_F(WriterConvertStateMachineState, convertsIdleState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kIdle);
-  ASSERT_EQ(convertedState, "IDLE") << idle_state_error;
+  ASSERT_EQ(convertedState, "IDLE") << "Should convert Idle state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsCalibratingState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kCalibrating);
-  ASSERT_EQ(convertedState, "CALIBRATING") << calibrating_state_error;
+  ASSERT_EQ(convertedState, "CALIBRATING") << "Should convert Calibrating state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsReadyState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kReady);
-  ASSERT_EQ(convertedState, "READY") << ready_state_error;
+  ASSERT_EQ(convertedState, "READY") << "Should convert Ready state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsAcceleratingState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kAccelerating);
-  ASSERT_EQ(convertedState, "ACCELERATING") << accelerating_state_error;
+  ASSERT_EQ(convertedState, "ACCELERATING") << "Should convert Accelerating state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsCruisingState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kCruising);
-  ASSERT_EQ(convertedState, "CRUISING") << cruising_state_error;
+  ASSERT_EQ(convertedState, "CRUISING") << "Should convert Cruising state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsNominalBrakingState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kNominalBraking);
-  ASSERT_EQ(convertedState, "NOMINAL_BRAKING") << nominal_braking_state_error;
+  ASSERT_EQ(convertedState, "NOMINAL_BRAKING") << "Should convert Nominal Braking state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsEmergencyBrakingState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kEmergencyBraking);
-  ASSERT_EQ(convertedState, "EMERGENCY_BRAKING") << emergency_braking_state_error;
+  ASSERT_EQ(convertedState, "EMERGENCY_BRAKING") << "Should convert Emergency Braking state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsFailureStoppedState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kFailureStopped);
-  ASSERT_EQ(convertedState, "FAILURE_STOPPED") << failure_stopped_state_error;
+  ASSERT_EQ(convertedState, "FAILURE_STOPPED") << "Should convert Failure Stopped state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsFinishedState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kFinished);
-  ASSERT_EQ(convertedState, "FINISHED") << finished_state_error;
+  ASSERT_EQ(convertedState, "FINISHED") << "Should convert Finished state.";
 }
 
 TEST_F(WriterConvertStateMachineState, convertsInvalidState)
 {
   std::string convertedState = Writer::convertStateMachineState(State::kInvalid);
-  ASSERT_EQ(convertedState, "INVALID") << invalid_state_error;
+  ASSERT_EQ(convertedState, "INVALID") << "Should convert Invalid state.";
 }


### PR DESCRIPTION
Deleted the variables that held error strings and put the strings inline for existing telemetry tests.