### PR TITLE
Bug fixing sending ID with each json package

### DIFF
--- a/src/telemetry/sender.cpp
+++ b/src/telemetry/sender.cpp
@@ -21,7 +21,7 @@ void Sender::run()
 {
   log_.debug("Telemetry Sender thread started");
 
-  uint16_t num_packages_sent = 0;
+  int num_packages_sent = 0;
 
   while (true) {
     Writer writer(data_);

--- a/src/telemetry/writer.cpp
+++ b/src/telemetry/writer.cpp
@@ -17,7 +17,7 @@ void Writer::packTime()
                         .count());
 }
 
-void Writer::packId(const uint16_t id)
+void Writer::packId(const int id)
 {
   json_writer_.Key("id");
   json_writer_.Int(id);

--- a/src/telemetry/writer.cpp
+++ b/src/telemetry/writer.cpp
@@ -20,7 +20,7 @@ void Writer::packTime()
 void Writer::packId(const uint16_t id)
 {
   json_writer_.Key("id");
-  add("package_num", id);
+  json_writer_.Int(id);
 }
 
 // Additional data points that are displayed in the GUI data section

--- a/src/telemetry/writer.hpp
+++ b/src/telemetry/writer.hpp
@@ -31,7 +31,7 @@ class Writer {
 
   // separate functions that allow to better manage data points based on their purpose
   void packTime();
-  void packId(uint16_t id);
+  void packId(int id);
   void packCrucialData();
   void packStatusData();
   void packAdditionalData();


### PR DESCRIPTION
ID (package number) value wasn't being sent with each json package because wrong "add" method overload was being used.