### PR TITLE
SNS: Macbook SPI fix

### DIFF
--- a/src/utils/io/spi.cpp
+++ b/src/utils/io/spi.cpp
@@ -12,7 +12,7 @@
 #if LINUX
 #include <linux/spi/spidev.h>
 #else
-#define _IOW(type, nr, size) 10  // random demo functionality
+#define _IOC_SIZEBITS 13
 #define SPI_IOC_MAGIC 'k'
 #define SPI_IOC_WR_MODE _IOW(SPI_IOC_MAGIC, 1, uint8_t)
 #define SPI_IOC_WR_MAX_SPEED_HZ _IOW(SPI_IOC_MAGIC, 4, uint32_t)

--- a/test/state_machine/transitions.test.cpp
+++ b/test/state_machine/transitions.test.cpp
@@ -87,7 +87,7 @@ TEST_F(TransitionFunctionality, handlesNoEmergency)
     motors_data.module_status             = other;
     telemetry_data.emergency_stop_command = false;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, false) << "falsely detected emergency";
   }
 }
@@ -118,7 +118,7 @@ TEST_F(TransitionFunctionality, handlesBrakeEmergency)
     motors_data.module_status             = other;
     telemetry_data.emergency_stop_command = false;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, true) << "failed to detect brake emergency";
   }
 }
@@ -149,7 +149,7 @@ TEST_F(TransitionFunctionality, handlesNavEmergency)
     motors_data.module_status             = other;
     telemetry_data.emergency_stop_command = false;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, true) << "failed to detect emergency in Navigation";
   }
 }
@@ -180,7 +180,7 @@ TEST_F(TransitionFunctionality, handlesBatteriesEmergency)
     motors_data.module_status             = other;
     telemetry_data.emergency_stop_command = false;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, true) << "failed to detect emergency in Batteries";
   }
 }
@@ -211,7 +211,7 @@ TEST_F(TransitionFunctionality, handlesTelemetryEmergency)
     motors_data.module_status             = other;
     telemetry_data.emergency_stop_command = false;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, true) << "failed to detect emergency in Telemetry";
   }
 }
@@ -242,7 +242,7 @@ TEST_F(TransitionFunctionality, handlesSensorsEmergency)
     motors_data.module_status             = other;
     telemetry_data.emergency_stop_command = false;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, true) << "failed to detect emergency in Sensors";
   }
 }
@@ -273,7 +273,7 @@ TEST_F(TransitionFunctionality, handlesMotorsEmergency)
     motors_data.module_status             = data::ModuleStatus::kCriticalFailure;
     telemetry_data.emergency_stop_command = false;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, true) << "failed to detect emergency in motors";
   }
 }
@@ -304,7 +304,7 @@ TEST_F(TransitionFunctionality, handlesStopCommand)
     motors_data.module_status             = other;
     telemetry_data.emergency_stop_command = true;
     const bool has_emergency              = state_machine::checkEmergency(
-                   log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(has_emergency, true) << "failed to register stop command";
   }
 }
@@ -337,7 +337,7 @@ TEST_F(TransitionFunctionality, handlesAllInitialised)
     sensors_data.module_status   = goal;
     motors_data.module_status    = goal;
     const bool all_initialised   = state_machine::checkModulesInitialised(
-        log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(all_initialised, true) << "failed to detect all modules being initialised";
   }
 }
@@ -369,7 +369,7 @@ TEST_F(TransitionFunctionality, handlesBrakesNotInitialised)
       sensors_data.module_status   = goal;
       motors_data.module_status    = goal;
       const bool all_initialised   = state_machine::checkModulesInitialised(
-          log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+        log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
       ASSERT_EQ(all_initialised, false) << "failed to detect uninitialised brakes";
     }
   }
@@ -402,7 +402,7 @@ TEST_F(TransitionFunctionality, handlesNavigationNotInitialised)
       sensors_data.module_status   = goal;
       motors_data.module_status    = goal;
       const bool all_initialised   = state_machine::checkModulesInitialised(
-          log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+        log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
       ASSERT_EQ(all_initialised, false) << "failed to detect Navigation not being initialised";
     }
   }
@@ -436,7 +436,7 @@ TEST_F(TransitionFunctionality, handlesBatteriesNotInitialised)
       sensors_data.module_status   = goal;
       motors_data.module_status    = goal;
       const bool all_initialised   = state_machine::checkModulesInitialised(
-          log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+        log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
       ASSERT_EQ(all_initialised, false) << "failed to detect Batteries not being initialised";
     }
   }
@@ -470,7 +470,7 @@ TEST_F(TransitionFunctionality, handlesTelemetryNotInitialised)
       sensors_data.module_status   = goal;
       motors_data.module_status    = goal;
       const bool all_initialised   = state_machine::checkModulesInitialised(
-          log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+        log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
       ASSERT_EQ(all_initialised, false) << "failed to detect Telemetry not being initialised";
     }
   }
@@ -504,7 +504,7 @@ TEST_F(TransitionFunctionality, handlesSensorsNotInitialised)
       sensors_data.module_status   = other;
       motors_data.module_status    = goal;
       const bool all_initialised   = state_machine::checkModulesInitialised(
-          log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+        log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
       ASSERT_EQ(all_initialised, false) << "failed to detect Sensors not being initialised";
     }
   }
@@ -538,7 +538,7 @@ TEST_F(TransitionFunctionality, handlesMotorsNotInitialised)
       sensors_data.module_status   = goal;
       motors_data.module_status    = other;
       const bool all_initialised   = state_machine::checkModulesInitialised(
-          log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+        log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
       ASSERT_EQ(all_initialised, false) << "failed to detect Motors not being initialise";
     }
   }
@@ -566,7 +566,7 @@ TEST_F(TransitionFunctionality, handlesAllReady)
   sensors_data.module_status   = data::ModuleStatus::kReady;
   motors_data.module_status    = data::ModuleStatus::kReady;
   const auto all_ready         = state_machine::checkModulesReady(
-            log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+    log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
   ASSERT_EQ(all_ready, true) << "failed to detect that all modules are ready";
 }
 
@@ -595,7 +595,7 @@ TEST_F(TransitionFunctionality, handlesBrakesNotReady)
     sensors_data.module_status   = data::ModuleStatus::kReady;
     motors_data.module_status    = data::ModuleStatus::kReady;
     const bool all_ready         = state_machine::checkModulesReady(
-              log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(all_ready, false) << "failed to detect Brakes not being ready";
   }
 }
@@ -625,7 +625,7 @@ TEST_F(TransitionFunctionality, handlesNavigationNotReady)
     sensors_data.module_status   = data::ModuleStatus::kReady;
     motors_data.module_status    = data::ModuleStatus::kReady;
     const bool all_ready         = state_machine::checkModulesReady(
-              log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(all_ready, false) << "failed to detect Navigation not being ready";
   }
 }
@@ -655,7 +655,7 @@ TEST_F(TransitionFunctionality, handlesBatteriesNotReady)
     sensors_data.module_status   = data::ModuleStatus::kReady;
     motors_data.module_status    = data::ModuleStatus::kReady;
     const bool all_ready         = state_machine::checkModulesReady(
-              log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(all_ready, false) << "failed to detect Batteries not being ready";
   }
 }
@@ -684,7 +684,7 @@ TEST_F(TransitionFunctionality, handlesTelemetryNotReady)
     sensors_data.module_status   = data::ModuleStatus::kReady;
     motors_data.module_status    = data::ModuleStatus::kReady;
     const bool all_ready         = state_machine::checkModulesReady(
-              log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(all_ready, false) << "failed to detect Telemetry not being ready";
   }
 }
@@ -714,7 +714,7 @@ TEST_F(TransitionFunctionality, handlesSensorsNotReady)
     sensors_data.module_status   = other;
     motors_data.module_status    = data::ModuleStatus::kReady;
     const bool all_ready         = state_machine::checkModulesReady(
-              log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(all_ready, false) << "failed to detect Sensors not being ready";
   }
 }
@@ -744,7 +744,7 @@ TEST_F(TransitionFunctionality, handlesMotorsNotReady)
     sensors_data.module_status   = data::ModuleStatus::kReady;
     motors_data.module_status    = other;
     const bool all_ready         = state_machine::checkModulesReady(
-              log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
+      log_, brakes_data, nav_data, batteries_data, telemetry_data, sensors_data, motors_data);
     ASSERT_EQ(all_ready, false) << "failed to detect Motors not being ready";
   }
 }


### PR DESCRIPTION
- Fixed SPI compilation on Mac
- Fixes auto formatting of state machine `transitions.test.cpp` 